### PR TITLE
Run docker with --gpus flag.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'django-unused-media',
         'djangorestframework',
         'docker',
+        'gputil',
         # 'psycopg2',
         'python-magic',
         'requests',

--- a/utils/Dockerfile-urban
+++ b/utils/Dockerfile-urban
@@ -1,0 +1,11 @@
+FROM joncrall/urban3d_v2:latest
+
+CMD bash -c '\
+mkdir /tmp/dataset >&2 && \
+tar -zxv -C /tmp/dataset >/dev/null && \
+ls -l /tmp/dataset >&2 && \
+source /root/conda_bashrc.sh >&2 && \
+python -m clab.live.final test --train_data_path=/data/training --test_data_path=/tmp/dataset --output_file=results >&2 && \
+cat results.txt \
+'
+

--- a/utils/build.sh
+++ b/utils/build.sh
@@ -5,3 +5,5 @@ docker build --force-rm -t rgd/catalgo -f Dockerfile-cat-algorithm .
 docker build --force-rm -t rgd/catalgobb -f Dockerfile-cat-algorithm-bb .
 docker build --force-rm -t rgd/xoralgo -f Dockerfile-xor-algorithm .
 docker build --force-rm -t rgd/binscorer -f Dockerfile-binary-scorer .
+docker build --force-rm -t rgd/urban3d_v2 -f Dockerfile-urban .
+


### PR DESCRIPTION
If there are available GPUs, this adds the --gpus flag to the docker run command.

Like in girder worker, we could check if we think it needs GPUs based on the docker image labels having nvidia information.  Otherwise, we need some way to know if we need a GPU worker, and, if so, how many GPUs are required.