### PR TITLE
Override default textarea to text input

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -4,6 +4,8 @@ from django.utils.safestring import mark_safe
 from django.utils.html import escape
 from django.template.defaultfilters import linebreaksbr
 from django.db.models import FileField
+# override the default textarea
+from django.forms import TextInput
 
 import os
 
@@ -42,6 +44,16 @@ def _text_preview(log_file: FileField):
     else:
         return 'No log file to display'
 
+# def formfield_for_dbfield(self, db_field, **kwargs):
+#     formfield = super().formfield_for_dbfield(db_field, **kwargs)
+#     if db_field.name == 'fail_reason':
+#         # check if return object value is empty
+#         if kwargs['fail_reason'] == None:
+#             return formfield
+#         else:
+#             # if not empty do not override
+#             return
+
 
 @admin_display(short_description='Run algorithm')
 def run_algorithm(modeladmin, request, queryset):
@@ -67,6 +79,13 @@ class AlgorithmAdmin(admin.ModelAdmin):
             return 'No attachment'
 
     data_link.allow_tags = True
+
+    # overrride default textfield model
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, **kwargs)
+        if db_field.name == 'docker_image_id':
+            formfield.widget = TextInput(attrs=formfield.widget.attrs)
+            return formfield
 
 
 @admin.register(models.AlgorithmJob)
@@ -104,6 +123,13 @@ class AlgorithmResultAdmin(admin.ModelAdmin):
 
     def log_preview(self, obj):
         return _text_preview(obj.log)
+
+    # overrride default textfield model from textarea to text input
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, **kwargs)
+        if db_field.name == 'data_mimetype':
+            formfield.widget = TextInput(attrs=formfield.widget.attrs)
+        return formfield
 
 
 @admin.register(models.Dataset)
@@ -149,6 +175,13 @@ class ScoreAlgorithmAdmin(admin.ModelAdmin):
             return 'No attachment'
 
     data_link.allow_tags = True
+
+    # overrride default textfield model
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, **kwargs)
+        if db_field.name == 'docker_image_id':
+            formfield.widget = TextInput(attrs=formfield.widget.attrs)
+        return formfield
 
 
 @admin.register(models.ScoreJob)

--- a/core/admin.py
+++ b/core/admin.py
@@ -74,7 +74,7 @@ class AlgorithmAdmin(admin.ModelAdmin):
         formfield = super().formfield_for_dbfield(db_field, **kwargs)
         if db_field.name == 'docker_image_id':
             formfield.widget = TextInput(attrs=formfield.widget.attrs)
-            return formfield
+        return formfield
 
 
 @admin.register(models.AlgorithmJob)
@@ -153,7 +153,7 @@ class GroundtruthAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.ScoreAlgorithm)
-class ScoreAlgorithmAdmin(admin.ModelAdmin):
+class ScoreAlgorithmAdmin(AlgorithmAdmin):
     list_display = ('__str__', 'task', 'creator', 'created', 'active', 'data_link')
     readonly_fields = ('data_link',)
 
@@ -164,12 +164,6 @@ class ScoreAlgorithmAdmin(admin.ModelAdmin):
             return 'No attachment'
 
     data_link.allow_tags = True
-
-    def formfield_for_dbfield(self, db_field, **kwargs):
-        formfield = super().formfield_for_dbfield(db_field, **kwargs)
-        if db_field.name == 'docker_image_id':
-            formfield.widget = TextInput(attrs=formfield.widget.attrs)
-        return formfield
 
 
 @admin.register(models.ScoreJob)

--- a/core/admin.py
+++ b/core/admin.py
@@ -153,17 +153,9 @@ class GroundtruthAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.ScoreAlgorithm)
+# subclassing AlgorithmAdmin to avoid duplicate codes
 class ScoreAlgorithmAdmin(AlgorithmAdmin):
     list_display = ('__str__', 'task', 'creator', 'created', 'active', 'data_link')
-    readonly_fields = ('data_link',)
-
-    def data_link(self, obj):
-        if obj.data:
-            return mark_safe('<a href="%s" download>Download</a>' % (obj.data.url,))
-        else:
-            return 'No attachment'
-
-    data_link.allow_tags = True
 
 
 @admin.register(models.ScoreJob)

--- a/core/admin.py
+++ b/core/admin.py
@@ -4,7 +4,6 @@ from django.utils.safestring import mark_safe
 from django.utils.html import escape
 from django.template.defaultfilters import linebreaksbr
 from django.db.models import FileField
-# override the default textarea
 from django.forms import TextInput
 
 import os
@@ -43,16 +42,6 @@ def _text_preview(log_file: FileField):
                 return 'Log is empty'
     else:
         return 'No log file to display'
-
-# def formfield_for_dbfield(self, db_field, **kwargs):
-#     formfield = super().formfield_for_dbfield(db_field, **kwargs)
-#     if db_field.name == 'fail_reason':
-#         # check if return object value is empty
-#         if kwargs['fail_reason'] == None:
-#             return formfield
-#         else:
-#             # if not empty do not override
-#             return
 
 
 @admin_display(short_description='Run algorithm')
@@ -176,7 +165,6 @@ class ScoreAlgorithmAdmin(admin.ModelAdmin):
 
     data_link.allow_tags = True
 
-    # overrride default textfield model
     def formfield_for_dbfield(self, db_field, **kwargs):
         formfield = super().formfield_for_dbfield(db_field, **kwargs)
         if db_field.name == 'docker_image_id':


### PR DESCRIPTION
Override docker_image_id and data_mimetype in formfield
I cannot find a way to override default textarea for fail_reason when it is empty.