### PR TITLE
This allows using a docker-based worker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ but allows developers to run the Python code on their native system.
 
 ### Initial Setup
 1. Run `./dev/init-minio.sh`
-2. Run `docker-compose -f ./docker-compose.yml up -d`
+2. Run `docker-compose -f ./docker-compose.yml -f ./docker-compose.native.yml up -d`
 3. Install Python 3.8
 4. Install [`psycopg2` build prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites)
 5. Create and activate a new Python virtualenv

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -28,7 +28,7 @@ def _field_file_to_local_path(field_file: FieldFile) -> Generator[Path, None, No
     with field_file.open('rb'):
         file_obj: File = field_file.file
 
-        if isinstance(file_obj, S3Boto3StorageFile):
+        if not Path(file_obj.name).exists() or isinstance(file_obj, S3Boto3StorageFile):
             field_file_basename = PurePath(field_file.name).name
             with tempfile.NamedTemporaryFile('wb', suffix=field_file_basename) as dest_stream:
                 shutil.copyfileobj(file_obj, dest_stream)

--- a/docker-compose.override.native.yml
+++ b/docker-compose.override.native.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  db:
+    ports:
+      - 5432:5432
+
+  rabbitmq:
+    ports:
+      - 5672:5672
+
+  minio:
+    ports:
+      - 9000:9000

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,8 @@ services:
     env_file: ./dev/.env.docker-compose
     volumes:
       - .:/opt/resonantgeodata
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/bin/docker:/usr/bin/docker
     depends_on:
       - db
       - rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,12 @@ services:
       POSTGRES_DB: rgd
       POSTGRES_PASSWORD: postgres
     volumes:
-      - /var/lib/postgresql/data
+      - "dbdata:/var/lib/postgresql/data"
 
   rabbitmq:
     image: rabbitmq:latest
+    volumes:
+      - mqdata:/var/lib/rabbitmq
 
   minio:
     image: minio/minio
@@ -18,4 +20,9 @@ services:
       MINIO_ACCESS_KEY: minioAdminAccessKey
       MINIO_SECRET_KEY: minioAdminSecretKey
     volumes:
-      - /data
+      - fsdata:/data
+
+volumes:
+  dbdata:
+  fsdata:
+  mqdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,9 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - /var/lib/postgresql/data
-    ports:
-      - 5432:5432
 
   rabbitmq:
     image: rabbitmq:latest
-    ports:
-      - 5672:5672
 
   minio:
     image: minio/minio
@@ -23,5 +19,3 @@ services:
       MINIO_SECRET_KEY: minioAdminSecretKey
     volumes:
       - /data
-    ports:
-      - 9000:9000


### PR DESCRIPTION
Some of our tasks run docker commands.  To do this within a docker container, it is necessary to mount the docker command and the docker socket.  This uses the default locations of each of these as deployed in ubuntu.

Further, one of the virtues of developing with docker is network separation.  However, since the ports were specified in the docker-compose.yml file, this wasn't full possible -- the docker development environment has no need to expose these to the host computer, and if the host already had one these ports in use it would fail.  This moves the port exposure to `docker-compose.override.native.yml`, and the instructions for using the native python have changed appropriately.