### PR TITLE
Allow downloading files from dockerized minio.

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('jobs/<str:creator>/<int:pk>/', views.JobDetailView.as_view(), name='job-detail'),
     path('tasks/', views.tasks, name='tasks'),
     path('task/<int:pk>-<str:name>/', views.TaskDetailView.as_view(), name='task-detail'),
+    path('api/download/<model>/<int:id>/<field>', views.download_file, name='download-file'),
 ]
 
 handler500 = views.handler500


### PR DESCRIPTION
The download url for dockerized minio includes the docker internal network name and port (e.g., starting with `http://minio:9000/`).  DNS should not be expected to resolve this, not should forwarding that port be needed for development.

This adds an api endpoint (`/api/download/<snake_case_model>/<id>/<field>`) which will download any FieldFile record in a core model.  The download is provided with the internal name of the file and, if known, a stored mimetype.

The download_file function is probably too open (though we should only load models based on some user authorization).  The explicit check for `//minio:` is ugly and brittle.

**Note**: I view this as the *wrong* way to fix downloading from minio, but I'm not sure of a better way to do it that actually works in our typical development environment without adding a proxy server to the mix.  Specifically, the development download code path is now *special* and not what we are using in production.  Further, downloads are sent through the main django process rather than being deferred to the storage system -- since the `minio` hostname is not exposed to the host computer (nor external computers accessing the host computer), some alteration of the url appears to be necessary no matter what.