### PR TITLE
Fix running scoring algorithms in docker deployment.

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -279,6 +279,10 @@ def _post_save_score_job(sender, instance, *args, **kwargs):
 
 
 class ScoreResult(models.Model):
+    class ResultTypes(models.TextChoices):
+        SIMPLE = 'simple', _('Direct value')
+        ROC = 'roc', _('Receiver Operating Characteristic')
+
     score_job = models.ForeignKey(ScoreJob, on_delete=models.CASCADE, blank=True, null=True)
     created = models.DateTimeField(default=timezone.now)
     data = models.FileField(upload_to='scores')
@@ -286,11 +290,6 @@ class ScoreResult(models.Model):
     overall_score = models.FloatField(
         null=True, blank=True, validators=[MaxValueValidator(1.0), MinValueValidator(0.0)]
     )
-
-    class ResultTypes(models.TextChoices):
-        SIMPLE = 'simple', _('Direct value')
-        ROC = 'roc', _('Receiver Operating Characteristic')
-
     result_type = models.CharField(
         max_length=10, choices=ResultTypes.choices, null=True, blank=True
     )

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,10 +22,13 @@ services:
       dockerfile: ./dev/Dockerfile
     command: ["celery", "worker", "--app", "rgd.celery", "--loglevel", "info", "--without-heartbeat"]
     env_file: ./dev/.env.docker-compose
+    environment:
+      - TMPDIR=/tmp/rgd_worker
     volumes:
       - .:/opt/resonantgeodata
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker
+      - /tmp/rgd_worker:/tmp/rgd_worker
     depends_on:
       - db
       - rabbitmq


### PR DESCRIPTION
When the worker is NOT a docker container, we can run a scoring algorithm, but when it IS a docker container, it fails.

Specifically, a scoring algorithm has two inputs: the output of an algorithm and the groundtruth.  We run a scoring algorithm via `docker run`.  The algorithm output is passed on stdin, the groundtruth is mounted as a file with the path `/groundtruth.dat`.  The scoring results are on stdout and logs on stderr.

When we are storing data on minio, the algorithm results and groundtruth are moved to local files via `_field_file_to_local_path`.  These are in the `/tmp` directory.  However, when we run a docker from within a docker, those `/tmp` paths are inside the worker docker container, and the scorer docker container can't reach them, even with a volume mount.

The solution is to mount a specific directory to share files between docker containers.  In this case, we mount /tmp/rgd_worker in the worker.  This directory has the same name on the host, and is therefore reachable by the scoring algorithm docker container.

Also, guard against failure to parse an overall score.