### PR TITLE
Don't use a volume for the rabbitmq container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:management
-    volumes:
-      - mqdata:/var/lib/rabbitmq
 
   minio:
     image: minio/minio
@@ -25,4 +23,3 @@ services:
 volumes:
   dbdata:
   fsdata:
-  mqdata:


### PR DESCRIPTION
On my local system, RabbitMQ was using 60+ GB in this volume.  Preserving state doesn't seem to be useful, so this is just wasted space. 