### PR TITLE
Update gitignore to include a local config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ files/
 
 #vscode
 .vscode
+
+# Ignore a local config file
+docker-compose.local.yml


### PR DESCRIPTION
This makes it more convenient for me to override docker-compose settings using a command like `docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.local.yml up`.