### PR TITLE
Set the basepython for tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist =
     lint,
     test,
 
+[testenv]
+basepython=python3.8
+
 [testenv:lint]
 skipsdist = true
 skip_install = true


### PR DESCRIPTION
Tox generally expects tests to be run with names like "py38" not "test".  If that is done, then the basepython is automatically extracted from the environment.  Specifying the basepython allows tox to run successfully in a multi-python environment.