### PR TITLE
Add GDAL to install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'django-debug-toolbar',
         'django-minio-storage',
         # GeoData
+        'GDAL',
         'rasterio',
         'fiona',
         'shapely',


### PR DESCRIPTION
Originally we were only getting GDAL to get the library files.  At some point we started using it directly, so it belongs in setup.py (not just requirements.txt -- we still need that to properly deploy on Heroku).