### PR TITLE
Change app import order to allow template overrides.

### DIFF
--- a/rgd/settings.py
+++ b/rgd/settings.py
@@ -17,7 +17,6 @@ class GeoDjangoConfig(ConfigMixin):
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
         configuration.INSTALLED_APPS += ['django.contrib.gis']
-
         try:
             import osgeo
             import re
@@ -115,11 +114,16 @@ class RgdConfig(
         # Accordingly, RgdConfig must be loaded after AllauthConfig, so it can
         # find the existing entry and insert accordingly.
         try:
-            allauth_index = configuration.INSTALLED_APPS.index('allauth')
+            insert_index = configuration.INSTALLED_APPS.index('allauth')
         except ValueError:
             raise Exception('RgdConfig must be loaded after AllauthConfig.')
-        configuration.INSTALLED_APPS.insert(allauth_index, 'geodata')
-        configuration.INSTALLED_APPS.insert(allauth_index, 'core')
+        # We also want our apps to be before any apps that we want to override
+        # the templates of
+        for key in {'drf_yasg'}:
+            if key in configuration.INSTALLED_APPS:
+                insert_index = min(insert_index, configuration.INSTALLED_APPS.index(key))
+        configuration.INSTALLED_APPS.insert(insert_index, 'geodata')
+        configuration.INSTALLED_APPS.insert(insert_index, 'core')
 
         configuration.INSTALLED_APPS += [
             'django.contrib.humanize',


### PR DESCRIPTION
I've been experimenting with a template override for drf-yasg.  The refactor to using `django-girders` for compositing config changed the app import order, breaking this.  This fixes it.  Generally, our local apps have to be installed before any app where we want to override a template (assuming we use `APP_DIRS: True` with templates).

For reference, my template override is some CSS styling to make the swagger page more compact.  This makes for better screen shots.  If others are interested in the more compact CSS, I can check that in as a different PR.