### PR TITLE
Implement an initial simple raster search and display.

### DIFF
--- a/geodata/models/raster/reader.py
+++ b/geodata/models/raster/reader.py
@@ -109,6 +109,14 @@ class RasterEntryReader(_ReaderRoutine):
             self.raster_entry.creator = self.rfe.creator
             self.raster_entry.modifier = self.rfe.modifier
 
+            # There is a potential conflict between rasterio and whatever GDAL
+            # is available.  Rastio has an older form of GDAL and conflicts
+            # with a system GDAL if the version is different.  So far, the only
+            # issue seems to be with rastio's <source>.crs.  We can work around
+            # this by using GDAL directly.
+            gsrc = gdal.Open(str(file_path))
+            spatial_ref_wkt = gsrc.GetSpatialRef().ExportToWkt()
+            spatial_ref = SpatialReference(spatial_ref_wkt)
             with rasterio.open(file_path) as src:
                 self.raster_entry.number_of_bands = src.count
                 self.raster_entry.driver = src.driver
@@ -140,17 +148,16 @@ class RasterEntryReader(_ReaderRoutine):
                     )
                 )
 
-                spatial_ref = SpatialReference(src.crs.to_wkt())
                 logger.info(f'Raster footprint SRID: {spatial_ref.srid}')
                 # This will convert the Polygon to the DB's SRID
                 self.raster_entry.outline = transform_geometry(
-                    Polygon(coords, srid=spatial_ref.srid), src.crs.to_wkt()
+                    Polygon(coords, srid=spatial_ref.srid), spatial_ref_wkt
                 )
                 try:
                     # Only implement for first band for now
                     vcoords = get_valid_data_footprint(src, 1)
                     self.raster_entry.footprint = transform_geometry(
-                        Polygon(vcoords, srid=spatial_ref.srid), src.crs.to_wkt()
+                        Polygon(vcoords, srid=spatial_ref.srid), spatial_ref_wkt
                     )
                 except Exception as e:  # TODO: be more clever about this
                     logger.info(f'Issue computing convex hull of non-null data: {e}')
@@ -160,8 +167,6 @@ class RasterEntryReader(_ReaderRoutine):
                 dtypes = src.dtypes
                 interps = src.colorinterp
 
-            # Rasterio is no longer open... using gdal directly:
-            gsrc = gdal.Open(str(file_path))  # Have to cast Path to str
             self.band_entries = []
             n = gsrc.RasterCount
             if n != self.raster_entry.number_of_bands:

--- a/geodata/templates/geodata/raster_entries.html
+++ b/geodata/templates/geodata/raster_entries.html
@@ -1,12 +1,22 @@
 {% extends "base.html" %}
 {% block content %}
 
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
 
   <h1 class="article-title">
     <span>Rasters</span>
   </h1>
   <hr/>
 
+  <form method="GET">
+    Longitude (deg): <input type="text" name="longitude" value="{{ request.GET.longitude }}">
+    Latitude (deg): <input type="text" name="latitude" value="{{ request.GET.latitude }}">
+    <br>
+    Proximity (m): <input type="text" name="radius" value="{{ request.GET.radius }}">
+    <input class="button" type="submit" value="Filter">
+  </form>
+
+  <div id="map" style="width:100%;height:300px"></div>
 
   <table class="table">
     <thead class="thead-dark">
@@ -29,5 +39,29 @@
     </tbody>
   </table>
 
+<script>
+  let extents = JSON.parse('{{ extents|escapejs }}');
+  let map = geo.map({node: '#map'})
+  map.createLayer('osm', {source: 'stamen-toner-lite'});
+  let layer = map.createLayer('feature', {features: ['polygon']});
+  let reader = geo.createFileReader('geojsonReader', {'layer': layer});
+  // reader.read(extents.collect, (features) => {
+  reader.read(extents.convex_hull, (features) => {
+    let range = {}
+    if (features[0].polygonCoordinates) {
+      features[0].polygonCoordinates().forEach(p => {
+        range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
+        range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
+        range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
+        range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
+      });
+    }
+    if (range.left !== undefined) {
+      map.bounds(range);
+      map.zoom(map.zoom() - 0.25);
+    }
+    map.draw();
+  });
+</script>
 
 {% endblock content %}

--- a/geodata/views.py
+++ b/geodata/views.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from django.db.models.fields.files import FieldFile
@@ -9,14 +10,31 @@ from django.views.generic import DetailView
 from rest_framework.decorators import api_view
 
 from . import models
+from . import search
 from .models.raster.base import RasterEntry
 
 
 class RasterEntriesListView(generic.ListView):
     model = RasterEntry
     context_object_name = 'rasters'
-    queryset = RasterEntry.objects.all()
     template_name = 'geodata/raster_entries.html'
+
+    def get_queryset(self):
+        # latitude, longitude, radius, time, timespan, and timefield
+        search_params = {}
+        for key in {'longitude', 'latitude', 'radius'}:
+            if self.request.GET.get(key):
+                try:
+                    search_params[key] = float(self.request.GET.get(key))
+                except ValueError:
+                    pass
+        return self.model.objects.filter(search.search_near_point_filter(search_params))
+
+    def get_context_data(self, *args, **kwargs):
+        # The returned query set is in self.object_list, not self.queryset
+        context = super().get_context_data(*args, **kwargs)
+        context['extents'] = json.dumps(search.extant_summary(self.object_list))
+        return context
 
 
 class RasterEntryDetailView(DetailView):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     python_requires='>=3.8.0',
     install_requires=[
         'celery',
-        'django',
+        'django>=3.1rc1',
         'django-admin-display',
         'django-allauth',
         'django-cleanup',


### PR DESCRIPTION
This also fixes some coordinate transform issues.  This requires upgrading to django 3.1 (which is currently in rc1, and is not
official).  Unfortunately, there is definitely code in djangorestframework with will fail in django 3.1 until drf has a new release.

Specifically, there is ambiguity in how django 3.0 handles GDAL 3 transforms.  Compounding the problem, rasterio is bundled with a GDAL 2.x library.  Django should be using our more complete GDAL 3 library, but depending on the import order of rasterio and osgeo, rasterio may not emit wkt coordinates in a consistent manner.

