### PR TITLE
Make test factory registration less fragile

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,10 +1,14 @@
 import pytest
+from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
-# Names must be imported into conftest, importing for side effects is not sufficient
-from .factories import *  # noqa: F401,F403
+from .factories import TaskFactory, UserFactory
 
 
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+register(TaskFactory)
+register(UserFactory)

--- a/core/tests/factories.py
+++ b/core/tests/factories.py
@@ -1,11 +1,9 @@
 from django.contrib.auth.models import User
 import factory.django
-from pytest_factoryboy import register
 
 from core import models
 
 
-@register
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
@@ -16,7 +14,6 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker('last_name')
 
 
-@register
 class TaskFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Task

--- a/geodata/tests/conftest.py
+++ b/geodata/tests/conftest.py
@@ -1,10 +1,14 @@
 import pytest
+from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
-# Names must be imported into conftest, importing for side effects is not sufficient
-from .factories import *  # noqa: F401,F403
+from .factories import DatasetFactory, UserFactory
 
 
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+register(DatasetFactory)
+register(UserFactory)

--- a/geodata/tests/factories.py
+++ b/geodata/tests/factories.py
@@ -1,11 +1,9 @@
 from django.contrib.auth.models import User
 import factory.django
-from pytest_factoryboy import register
 
 from geodata import models
 
 
-@register
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
@@ -16,7 +14,6 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker('last_name')
 
 
-@register
 class DatasetFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Dataset


### PR DESCRIPTION
This removes the use of pytest_factorboy's @factory decorator as a matter of policy, as it's too fragile. Factories must be explicitly imported (if they are defined elsewhere) and registered in conftest.py.

The register function / decorator works by defining a new fixture function into the local Python file namespace. Pytest only automatically detects and registers global fixtures if they are within the namespace of conftest.py; fixtures defined as part of an import of other files are not registered.