### PR TITLE
Improve swagger descriptions.

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -25,6 +25,13 @@ class DeferredFieldsManager(models.Manager):
 
 
 class Task(models.Model):
+    """
+    Data processing task.
+
+    A task is a conceptual activity.  Datasets associated with a task, when
+    processed by appropriate algorithms, produce results.
+    """
+
     def __str__(self):
         return self.name
 
@@ -39,6 +46,12 @@ class Task(models.Model):
 
 
 class Dataset(models.Model):
+    """
+    Dataset for algorithms.
+
+    A dataset is a combined set of inputs for an algorithm.
+    """
+
     def __str__(self):
         return self.name
 
@@ -55,6 +68,13 @@ class Dataset(models.Model):
 
 
 class Groundtruth(models.Model):
+    """
+    Groundtruth.
+
+    Groundtruth is the expected output of a specific algorithm on a specific
+    dataset.
+    """
+
     # The data used by the scorer to compare the output of the algorithm
 
     def __str__(self):
@@ -80,6 +100,13 @@ class Groundtruth(models.Model):
 
 
 class Algorithm(models.Model):
+    """
+    Data processing alogorithm.
+
+    An algorithm is a docker image that takes a dataset on stdin, outputs logs
+    on stderr and results on stdout.
+    """
+
     def __str__(self):
         return self.name
 
@@ -126,6 +153,14 @@ def _post_save_algorithm(sender, instance, *args, **kwargs):
 
 
 class ScoreAlgorithm(models.Model):
+    """
+    Scoring alogorithm.
+
+    A scoring algorithm is a docker image that takes results from an algorithm
+    on stdin and groundtruth as a file at /groundtruth.dat, then outputs logs
+    on stderr and results on stdout.
+    """
+
     def __str__(self):
         return self.name
 
@@ -170,6 +205,12 @@ def _post_save_score_algorithm(sender, instance, *args, **kwargs):
 
 
 class AlgorithmJob(models.Model):
+    """
+    Algorithm job.
+
+    An algorithm job tracks running an algorithm on a specific dataset.
+    """
+
     class Meta:
         ordering = ['-created']
 
@@ -223,7 +264,12 @@ def _post_save_algorithm_job(sender, instance, *args, **kwargs):
 
 
 class AlgorithmResult(models.Model):
-    """NOTE: this is really a 'job result', not an 'algorithm result'..."""
+    """
+    Algorithm result.
+
+    When an algorithm job runs an algorithm on a dataset, it produces an
+    algorithm result.
+    """
 
     algorithm_job = models.ForeignKey(AlgorithmJob, on_delete=models.CASCADE, blank=True, null=True)
     created = models.DateTimeField(default=timezone.now)
@@ -233,6 +279,13 @@ class AlgorithmResult(models.Model):
 
 
 class ScoreJob(models.Model):
+    """
+    Score job.
+
+    A score job tracks running a scoring algorithm on algorithm results and the
+    groundtruth associated with the algorithm job's dataset.
+    """
+
     class Status(models.TextChoices):
         CREATED = 'created', _('Created but not queued')
         QUEUED = 'queued', _('Queued for processing')

--- a/core/urls.py
+++ b/core/urls.py
@@ -29,6 +29,7 @@ for _, ser in inspect.getmembers(serializers):
                 'filterset_fields': utility.get_filter_fields(model),
             },
         )
+        viewset_class.__doc__ = model.__doc__
         router.register('api/%s' % (model_name.lower()), viewset_class)
 
 admin.site.index_template = 'admin/add_links.html'

--- a/core/views.py
+++ b/core/views.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.encoding import smart_str
 from django.views.decorators.http import require_http_methods
 from django.views.generic import CreateView, DeleteView, DetailView
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
 
 from . import models
@@ -122,6 +123,11 @@ class JobCreateView(LoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
+@swagger_auto_schema(
+    method='GET',
+    operation_summary='Download a model file',
+    operation_description='Download a model file through the server instead of from the assetstore',
+)
 @api_view(['GET'])
 def download_file(request, model, id, field):
     model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])

--- a/geodata/search.py
+++ b/geodata/search.py
@@ -86,6 +86,7 @@ def search_near_point_filter(params):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='List geospatial datasets near a point',
     operation_description='List geospatial datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )
@@ -98,6 +99,7 @@ def search_near_point(request, *args, **kwargs):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='List raster datasets near a point',
     operation_description='List geospatial raster datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )
@@ -110,6 +112,7 @@ def search_near_point_raster(request, *args, **kwargs):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='List geometry datasets near a point',
     operation_description='List geospatial geometry datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )
@@ -188,6 +191,7 @@ def extant_summary_http(found):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='Extents of geospatial datasets near a point',
     operation_description='Get the convex hull and time range for geospatial datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )
@@ -200,6 +204,7 @@ def search_near_point_extent(request, *args, **kwargs):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='Extents of raster datasets near a point',
     operation_description='Get the convex hull and time range for geospatial raster datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )
@@ -212,6 +217,7 @@ def search_near_point_extent_raster(request, *args, **kwargs):
 
 @swagger_auto_schema(
     method='GET',
+    operation_summary='Extents of geometry datasets near a point',
     operation_description='Get the convex hull and time range for geospatial geometry datasets near a specific latitude and longitude',
     query_serializer=NearPointSerializer,
 )

--- a/geodata/views.py
+++ b/geodata/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404  # , render
 from django.utils.encoding import smart_str
 from django.views import generic
 from django.views.generic import DetailView
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
 
 from . import models
@@ -41,6 +42,11 @@ class RasterEntryDetailView(DetailView):
     model = RasterEntry
 
 
+@swagger_auto_schema(
+    method='GET',
+    operation_summary='Download a model file',
+    operation_description='Download a model file through the server instead of from the assetstore',
+)
 @api_view(['GET'])
 def download_file(request, model, id, field):
     model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])


### PR DESCRIPTION
Some swagger clients show summaries or descriptions rather than the endpoint as the primary menu item.  As such, make sure these are populated.

We should always populate the `operation_summary` if we specify an `operation_description` in `swagger_auto_schema`.

If we add model __doc__ strings, when we auto-generate views to generate swagger API, the first line become the summary and the rest of the docstring becomes the description.