### PR TITLE
Use a larger Heroku dyno for the web server

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,5 +44,6 @@ module "django" {
   additional_django_vars = {
     DJANGO_S3FF_UPLOAD_STS_ARN = aws_iam_role.storage_upload.arn
   }
+  heroku_web_dyno_size = "standard-2x"
   heroku_worker_dyno_quantity = 0
 }


### PR DESCRIPTION
Instead of the default "hobby" dyno, this will use a "standard-2x" dyno.

From https://devcenter.heroku.com/articles/dyno-types , the important differences are:
| Dyno Type | Memory (RAM) | Relative Compute Performance | $ / month | $ / year |
|---|---|---|---|---|
| hobby | 512 MB | 1x-4x | $7 | $84 |
| standard-1x | 512 MB | 1x-4x | $25 | $300 |
| standard-2x | 1024 MB | 4x-8x | $50 | $600 |
| performance-m | 2.5 GB | 11x | $250 | $3000 |
| performance-l | 14 GB | 46x | $500 | $6000 |

This will bump our service costs for the web dyno from $84/year to $600/year. Compared to even a few hours of developer labor, this is relatively cheap, but I realize that these numbers are often not directly comparable. So, as an alternative to this change, we could invest some effort into auditing and shrinking the memory footprint of the server.

A Django web server should typically not require over 512MB to run. Workers may require more than this, but we want to deploy those to EC2 instead, which has more favorable memory balances and GPU support. One possible source of memory bloat could be the side effects of importing third party modules. Rather than doing these imports [at the file level](https://github.com/ResonantGeoData/ResonantGeoData/blob/f069aaea215019e75088761bed31eb48fb59ab02/geodata/models/imagery/etl.py#L5-L7), where the web server will also import them, they could be done only within the functions that actually need them, which will practically only be executed by the worker.