### PR TITLE
Require a working version of S3FF to force upgrades

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'django-girders',
         'django-filter',
         'django-model-utils',
-        'django-s3-file-field',
+        'django-s3-file-field>=0.0.11',
         'django-storages',
         'djangorestframework',
         'djproxy',


### PR DESCRIPTION
This fixes the issues with Docker Compose Minio not respecting uploads. In particular, S3FF now respects the `MINIO_STORAGE_MEDIA_URL` setting.

@manthey Is there any workaround code which should be removed?