### PR TITLE
Remove imports of deprecated "django.conf.urls.url"

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,8 +1,7 @@
 import inspect
 
-from django.conf.urls import include
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from django_filters.rest_framework import DjangoFilterBackend
 from djproxy.urls import generate_routes
 from rest_framework import viewsets

--- a/rgd/urls.py
+++ b/rgd/urls.py
@@ -1,9 +1,8 @@
 import re
 
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.inspectors.view import SwaggerAutoSchema
 from drf_yasg.views import get_schema_view
@@ -77,13 +76,13 @@ schema_view = get_schema_view(
 )
 
 urlpatterns += [
-    url(
+    re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',
         schema_view.without_ui(cache_timeout=0),
         name='schema-json',
     ),
-    url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
This is deprecrated by Django 3.1.

Also fix imports of the "include" function to use the canonical location.