### PR TITLE
Make search viewer reusable

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -112,6 +112,9 @@
                   <a class="mr-2" href="{% url 'jobs' %}">My Jobs</a>
                 </li>
                 <li class="list-group-item list-group-item-dark">
+                  <a class="mr-2" href="{% url 'spatial_entries' %}">Spatial Entries</a>
+                </li>
+                <li class="list-group-item list-group-item-dark">
                   <a class="mr-2" href="{% url 'rasters' %}">Raster Entries</a>
                 </li>
               </ul>

--- a/geodata/search.py
+++ b/geodata/search.py
@@ -123,14 +123,14 @@ def search_near_point_geometry(request, *args, **kwargs):
     return JsonResponse(serializers.GeometryEntrySerializer(results, many=True).data, safe=False)
 
 
-def extent_summary(found):
+def extent_summary_spatial(found):
     """
-    Given a query set of items, return a result dictionary with the summary.
+    Given a query set of SpatialEntry, return a result dictionary with the summary.
 
     :param found: a query set with SpatialEntry results.
     :returns: a dictionary with count, collect, convex_hull, extent,
-        acquisition, acqusition_date, created, modified.  collect and
-        convex_hull are geojson objects.
+        acquisition, acqusition_date.  collect and convex_hull are geojson
+        objects.
     """
     if found and found.count():
         summary = found.aggregate(
@@ -138,12 +138,6 @@ def extent_summary(found):
             Extent('footprint'),
             Min('acquisition_date'),
             Max('acquisition_date'),
-            Min('created'),
-            Max('created'),
-            Min('modified'),
-            Max('modified'),
-            acquisition__min=Min(Coalesce('acquisition_date', 'created')),
-            acquisition__max=Max(Coalesce('acquisition_date', 'created')),
         )
         results = {
             'count': found.count(),
@@ -155,10 +149,6 @@ def extent_summary(found):
                 'xmax': summary['footprint__extent'][2],
                 'ymax': summary['footprint__extent'][3],
             },
-            'acquisition': [
-                summary['acquisition__min'].isoformat(),
-                summary['acquisition__max'].isoformat(),
-            ],
             'acquisition_date': [
                 summary['acquisition_date__min'].isoformat()
                 if summary['acquisition_date__min'] is not None
@@ -167,6 +157,30 @@ def extent_summary(found):
                 if summary['acquisition_date__max'] is not None
                 else None,
             ],
+        }
+    else:
+        results = {'count': 0}
+    return results
+
+
+def extent_summary_modifiable(found):
+    """
+    Given a query set of ModifiableEntry, return a result dictionary with the summary.
+
+    :param found: a query set with SpatialEntry results.
+    :returns: a dictionary with count, collect, convex_hull, extent,
+        acquisition, acqusition_date, created, modified.  collect and
+        convex_hull are geojson objects.
+    """
+    if found and found.count():
+        summary = found.aggregate(
+            Min('created'),
+            Max('created'),
+            Min('modified'),
+            Max('modified'),
+        )
+        results = {
+            'count': found.count(),
             'created': [summary['created__min'].isoformat(), summary['created__max'].isoformat()],
             'modified': [
                 summary['modified__min'].isoformat(),
@@ -175,6 +189,12 @@ def extent_summary(found):
         }
     else:
         results = {'count': 0}
+    return results
+
+
+def extent_summary(found):
+    results = extent_summary_modifiable(found)
+    results.update(extent_summary_spatial(found))
     return results
 
 

--- a/geodata/search.py
+++ b/geodata/search.py
@@ -6,7 +6,6 @@ from django.contrib.gis.db.models import Collect, Extent
 from django.contrib.gis.geos import Point
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db.models import Max, Min, Q
-from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers as rfserializers

--- a/geodata/search.py
+++ b/geodata/search.py
@@ -123,7 +123,7 @@ def search_near_point_geometry(request, *args, **kwargs):
     return JsonResponse(serializers.GeometryEntrySerializer(results, many=True).data, safe=False)
 
 
-def extant_summary(found):
+def extent_summary(found):
     """
     Given a query set of items, return a result dictionary with the summary.
 
@@ -178,14 +178,14 @@ def extant_summary(found):
     return results
 
 
-def extant_summary_http(found):
+def extent_summary_http(found):
     """
     Given a query set of items, return an http response with the summary.
 
     :param found: a query set with SpatialEntry results.
     :returns: an HttpResponse.
     """
-    results = extant_summary(found)
+    results = extent_summary(found)
     return HttpResponse(json.dumps(results), content_type='application/json')
 
 
@@ -199,7 +199,7 @@ def extant_summary_http(found):
 def search_near_point_extent(request, *args, **kwargs):
     params = request.query_params
     found = SpatialEntry.objects.filter(search_near_point_filter(params))
-    return extant_summary_http(found)
+    return extent_summary_http(found)
 
 
 @swagger_auto_schema(
@@ -212,7 +212,7 @@ def search_near_point_extent(request, *args, **kwargs):
 def search_near_point_extent_raster(request, *args, **kwargs):
     params = request.query_params
     found = RasterEntry.objects.filter(search_near_point_filter(params))
-    return extant_summary_http(found)
+    return extent_summary_http(found)
 
 
 @swagger_auto_schema(
@@ -225,4 +225,4 @@ def search_near_point_extent_raster(request, *args, **kwargs):
 def search_near_point_extent_geometry(request, *args, **kwargs):
     params = request.query_params
     found = GeometryEntry.objects.filter(search_near_point_filter(params))
-    return extant_summary_http(found)
+    return extent_summary_http(found)

--- a/geodata/templates/geodata/_includes/point_search.html
+++ b/geodata/templates/geodata/_includes/point_search.html
@@ -1,0 +1,73 @@
+{% block content %}
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
+
+  <form method="GET">
+    Longitude (deg): <input type="text" name="longitude" value="{{ request.GET.longitude }}">
+    Latitude (deg): <input type="text" name="latitude" value="{{ request.GET.latitude }}">
+    <br>
+    Proximity (m): <input type="text" name="radius" value="{{ request.GET.radius }}">
+    <input class="button" type="submit" value="Filter">
+  </form>
+
+  <div id="map" style="width:100%;height:600px"></div>
+
+  <script>
+    let extents = JSON.parse('{{ extents|escapejs }}');
+    let search_params = JSON.parse('{{ search_params|escapejs }}');
+    console.log(search_params)
+    let map = geo.map({
+      node: '#map'
+    })
+    map.createLayer('osm', {
+      source: 'osm'
+    }); // stamen-terrain
+    let layer = map.createLayer('feature', {
+      features: ['polygon']
+    });
+    // Add collected data to map
+    let reader = geo.createFileReader('geojsonReader', {
+      'layer': layer
+    });
+    reader.read(extents.collect, (features) => {
+      // reader.read(extents.convex_hull, (features) => {
+      let range = {}
+      if (features[0].polygonCoordinates) {
+        features[0].polygonCoordinates().forEach(p => {
+          console.log('doing it')
+          range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
+          range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
+          range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
+          range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
+        });
+      }
+      if (range.left !== undefined) {
+        map.bounds(range);
+        map.zoom(map.zoom() - 0.25);
+      }
+      map.draw();
+    });
+    // Add marker to map to show search location
+    if (search_params.longitude != undefined && search_params.latitude != undefined) {
+      var data = [{
+        lon: search_params.longitude,
+        lat: search_params.latitude
+      }, ]
+      console.log(data)
+      var feature = layer.createFeature('marker')
+        .data(data)
+        .position(function(marker) {
+          return {
+            x: marker.lon,
+            y: marker.lat
+          };
+        })
+        .draw();
+      map.center({
+        x: search_params.longitude,
+        y: search_params.latitude
+      })
+      map.zoom(13)
+    }
+  </script>
+
+{% endblock %}

--- a/geodata/templates/geodata/_includes/point_search.html
+++ b/geodata/templates/geodata/_includes/point_search.html
@@ -1,6 +1,4 @@
 {% block content %}
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
-
   <form method="GET">
     Longitude (deg): <input type="text" name="longitude" value="{{ request.GET.longitude }}">
     Latitude (deg): <input type="text" name="latitude" value="{{ request.GET.latitude }}">
@@ -9,65 +7,6 @@
     <input class="button" type="submit" value="Filter">
   </form>
 
-  <div id="map" style="width:100%;height:600px"></div>
-
-  <script>
-    let extents = JSON.parse('{{ extents|escapejs }}');
-    let search_params = JSON.parse('{{ search_params|escapejs }}');
-    console.log(search_params)
-    let map = geo.map({
-      node: '#map'
-    })
-    map.createLayer('osm', {
-      source: 'osm'
-    }); // stamen-terrain
-    let layer = map.createLayer('feature', {
-      features: ['polygon']
-    });
-    // Add collected data to map
-    let reader = geo.createFileReader('geojsonReader', {
-      'layer': layer
-    });
-    reader.read(extents.collect, (features) => {
-      // reader.read(extents.convex_hull, (features) => {
-      let range = {}
-      if (features[0].polygonCoordinates) {
-        features[0].polygonCoordinates().forEach(p => {
-          console.log('doing it')
-          range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
-          range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
-          range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
-          range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
-        });
-      }
-      if (range.left !== undefined) {
-        map.bounds(range);
-        map.zoom(map.zoom() - 0.25);
-      }
-      map.draw();
-    });
-    // Add marker to map to show search location
-    if (search_params.longitude != undefined && search_params.latitude != undefined) {
-      var data = [{
-        lon: search_params.longitude,
-        lat: search_params.latitude
-      }, ]
-      console.log(data)
-      var feature = layer.createFeature('marker')
-        .data(data)
-        .position(function(marker) {
-          return {
-            x: marker.lon,
-            y: marker.lat
-          };
-        })
-        .draw();
-      map.center({
-        x: search_params.longitude,
-        y: search_params.latitude
-      })
-      map.zoom(13)
-    }
-  </script>
+  {% include 'geodata/_includes/viewer.html' %}
 
 {% endblock %}

--- a/geodata/templates/geodata/_includes/viewer.html
+++ b/geodata/templates/geodata/_includes/viewer.html
@@ -1,0 +1,64 @@
+{% block content %}
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
+
+  <div id="map" style="width:100%;height:600px"></div>
+
+  <script>
+    let extents = JSON.parse('{{ extents|escapejs }}');
+    let search_params = JSON.parse('{{ search_params|escapejs }}');
+    console.log(search_params)
+    let map = geo.map({
+      node: '#map'
+    })
+    map.createLayer('osm', {
+      source: 'osm'
+    }); // stamen-terrain
+    let layer = map.createLayer('feature', {
+      features: ['polygon']
+    });
+    // Add collected data to map
+    let reader = geo.createFileReader('geojsonReader', {
+      'layer': layer
+    });
+    reader.read(extents.collect, (features) => {
+      // reader.read(extents.convex_hull, (features) => {
+      let range = {}
+      if (features[0].polygonCoordinates) {
+        features[0].polygonCoordinates().forEach(p => {
+          console.log('doing it')
+          range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
+          range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
+          range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
+          range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
+        });
+      }
+      if (range.left !== undefined) {
+        map.bounds(range);
+        map.zoom(map.zoom() - 0.25);
+      }
+      map.draw();
+    });
+    // Add marker to map to show search location
+    if (search_params.longitude != undefined && search_params.latitude != undefined) {
+      var data = [{
+        lon: search_params.longitude,
+        lat: search_params.latitude
+      }, ]
+      console.log(data)
+      var feature = layer.createFeature('marker')
+        .data(data)
+        .position(function(marker) {
+          return {
+            x: marker.lon,
+            y: marker.lat
+          };
+        })
+        .draw();
+      map.center({
+        x: search_params.longitude,
+        y: search_params.latitude
+      })
+      map.zoom(13)
+    }
+  </script>
+{% endblock %}

--- a/geodata/templates/geodata/_includes/viewer.html
+++ b/geodata/templates/geodata/_includes/viewer.html
@@ -14,37 +14,26 @@
       source: 'osm'
     }); // stamen-terrain
     let layer = map.createLayer('feature', {
-      features: ['polygon']
+      features: ['polygon', 'marker']
     });
     // Add collected data to map
     let reader = geo.createFileReader('geojsonReader', {
       'layer': layer
     });
-    reader.read(extents.collect, (features) => {
-      // reader.read(extents.convex_hull, (features) => {
-      let range = {}
-      if (features[0].polygonCoordinates) {
-        features[0].polygonCoordinates().forEach(p => {
-          console.log('doing it')
-          range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
-          range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
-          range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
-          range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
-        });
-      }
-      if (range.left !== undefined) {
-        map.bounds(range);
-        map.zoom(map.zoom() - 0.25);
-      }
-      map.draw();
+    reader.read(extents.collect); 
+    map.bounds({
+      left: extents.extent.xmin,
+      right: extents.extent.xmax,
+      top: extents.extent.ymax,
+      bottom: extents.extent.ymin
     });
+    map.zoom(map.zoom() - 0.25);
     // Add marker to map to show search location
     if (search_params.longitude != undefined && search_params.latitude != undefined) {
       var data = [{
         lon: search_params.longitude,
         lat: search_params.latitude
       }, ]
-      console.log(data)
       var feature = layer.createFeature('marker')
         .data(data)
         .position(function(marker) {
@@ -54,11 +43,6 @@
           };
         })
         .draw();
-      map.center({
-        x: search_params.longitude,
-        y: search_params.latitude
-      })
-      map.zoom(13)
     }
   </script>
 {% endblock %}

--- a/geodata/templates/geodata/raster_entries.html
+++ b/geodata/templates/geodata/raster_entries.html
@@ -8,15 +8,7 @@
   </h1>
   <hr/>
 
-  <form method="GET">
-    Longitude (deg): <input type="text" name="longitude" value="{{ request.GET.longitude }}">
-    Latitude (deg): <input type="text" name="latitude" value="{{ request.GET.latitude }}">
-    <br>
-    Proximity (m): <input type="text" name="radius" value="{{ request.GET.radius }}">
-    <input class="button" type="submit" value="Filter">
-  </form>
-
-  <div id="map" style="width:100%;height:300px"></div>
+  {% include 'geodata/_includes/point_search.html' %}
 
   <table class="table">
     <thead class="thead-dark">
@@ -38,30 +30,5 @@
       {% endfor %}
     </tbody>
   </table>
-
-<script>
-  let extents = JSON.parse('{{ extents|escapejs }}');
-  let map = geo.map({node: '#map'})
-  map.createLayer('osm', {source: 'stamen-toner-lite'});
-  let layer = map.createLayer('feature', {features: ['polygon']});
-  let reader = geo.createFileReader('geojsonReader', {'layer': layer});
-  // reader.read(extents.collect, (features) => {
-  reader.read(extents.convex_hull, (features) => {
-    let range = {}
-    if (features[0].polygonCoordinates) {
-      features[0].polygonCoordinates().forEach(p => {
-        range.left = range.left === undefined || p.range.min.x < range.left ? p.range.min.x : range.left;
-        range.right = range.right === undefined || p.range.max.x > range.right ? p.range.max.x : range.right;
-        range.bottom = range.bottom === undefined || p.range.min.y < range.bottom ? p.range.min.y : range.bottom;
-        range.top = range.top === undefined || p.range.max.y > range.top ? p.range.max.y : range.top;
-      });
-    }
-    if (range.left !== undefined) {
-      map.bounds(range);
-      map.zoom(map.zoom() - 0.25);
-    }
-    map.draw();
-  });
-</script>
 
 {% endblock content %}

--- a/geodata/templates/geodata/spatial_entries.html
+++ b/geodata/templates/geodata/spatial_entries.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
+
+  <h1 class="article-title">
+    <span>Spatial Entries</span>
+  </h1>
+  <hr/>
+
+  {% include 'geodata/_includes/viewer.html' %}
+
+  <table class="table">
+    <thead class="thead-dark">
+      <tr>
+        <th>Name (ID)</th>
+        <th>Acquisition Date</th>
+        <th>Area</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in spatial_entries %}
+        <tr>
+          <td>({{ entry.spatial_id }})</td>
+          <td>{{ entry.acquisition_date }}</td>
+          <td>{{ entry.footprint.area }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+{% endblock content %}

--- a/geodata/urls.py
+++ b/geodata/urls.py
@@ -3,7 +3,9 @@ from django.urls import path
 from . import search, views
 
 urlpatterns = [
-    path('geodata/spatial_entries/', views.SpatialEntriesListView.as_view(), name='spatial_entries'),
+    path(
+        'geodata/spatial_entries/', views.SpatialEntriesListView.as_view(), name='spatial_entries'
+    ),
     path('geodata/rasters/', views.RasterEntriesListView.as_view(), name='rasters'),
     path(
         'geodata/rasters/<int:pk>/',

--- a/geodata/urls.py
+++ b/geodata/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import search, views
 
 urlpatterns = [
+    path('geodata/spatial_entries/', views.SpatialEntriesListView.as_view(), name='spatial_entries'),
     path('geodata/rasters/', views.RasterEntriesListView.as_view(), name='rasters'),
     path(
         'geodata/rasters/<int:pk>/',

--- a/geodata/views.py
+++ b/geodata/views.py
@@ -11,10 +11,11 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
 
 from . import models, search
+from .models.common import SpatialEntry
 from .models.imagery.base import RasterEntry
 
 
-class _BasicListView(generic.ListView):
+class _SpatialListView(generic.ListView):
     def get_queryset(self):
         # latitude, longitude, radius, time, timespan, and timefield
         self.search_params = {}
@@ -29,15 +30,21 @@ class _BasicListView(generic.ListView):
     def get_context_data(self, *args, **kwargs):
         # The returned query set is in self.object_list, not self.queryset
         context = super().get_context_data(*args, **kwargs)
-        context['extents'] = json.dumps(search.extent_summary(self.object_list))
+        context['extents'] = json.dumps(search.extent_summary_spatial(self.object_list))
         context['search_params'] = json.dumps(self.search_params)
         return context
 
 
-class RasterEntriesListView(_BasicListView):
+class RasterEntriesListView(_SpatialListView):
     model = RasterEntry
     context_object_name = 'rasters'
     template_name = 'geodata/raster_entries.html'
+
+
+class SpatialEntriesListView(_SpatialListView):
+    model = SpatialEntry
+    context_object_name = 'spatial_entries'
+    template_name = 'geodata/spatial_entries.html'
 
 
 class RasterEntryDetailView(DetailView):

--- a/geodata/views.py
+++ b/geodata/views.py
@@ -15,7 +15,6 @@ from .models.imagery.base import RasterEntry
 
 
 class _BasicListView(generic.ListView):
-
     def get_queryset(self):
         # latitude, longitude, radius, time, timespan, and timefield
         self.search_params = {}

--- a/geodata/views.py
+++ b/geodata/views.py
@@ -29,7 +29,7 @@ class _BasicListView(generic.ListView):
     def get_context_data(self, *args, **kwargs):
         # The returned query set is in self.object_list, not self.queryset
         context = super().get_context_data(*args, **kwargs)
-        context['extents'] = json.dumps(search.extant_summary(self.object_list))
+        context['extents'] = json.dumps(search.extent_summary(self.object_list))
         context['search_params'] = json.dumps(self.search_params)
         return context
 


### PR DESCRIPTION
This makes the viewer reusable. My goal in doing this is to give us one single viewer that we can place on any page and it will automatically display the search parameters and data footprints that are loaded from the page's context

This will enable us to more easily define any type of seach-by page for any model. I am doing this to have a search page for FMV over in #143 

Currently, this assumes the search parameters are a single point but when we add other search parameters, we can update this to handle those cases.