### PR TITLE
Fix Heroku deployment.

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -21,8 +21,8 @@ ENV PYTHONUNBUFFERED 1
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
 COPY ./setup.py /opt/django/setup.py
-COPY ./requirements.txt /opt/django/requirements.txt
 WORKDIR /opt/django
 RUN pip install \
-    -r requirements.txt \
+    --find-links https://girder.github.io/large_image_wheels \
+    GDAL \
     -e .[dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # This is used by heroku for deployment
 --find-links https://girder.github.io/large_image_wheels
 GDAL
+# Heroku only uses CPU
+# See https://download.pytorch.org/whl/torch_stable.html for a list of wheels.
+https://download.pytorch.org/whl/cpu/torch-1.6.0%2Bcpu-cp38-cp38-linux_x86_64.whl
 # Install the app itself 
 -e .

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.5
+python-3.8.6


### PR DESCRIPTION
Only install pytorch for CPU.

Heroku has a limit to how many packages can be installed, set to a compressed size of 500 MB.  Pytorch alone, by default, takes around 750 Mb.  By using the cpu-only version we are below but still close to the limit.