### PR TITLE
Update Kwiver Dockerfile

### DIFF
--- a/utils/Dockerfile-kwiver-dump-klv
+++ b/utils/Dockerfile-kwiver-dump-klv
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   cat video.mpg | docker run -i banesullivan/kwiver:dump-klv > video.klv
-FROM banesullivan/kwiver:latest
+FROM kitware/kwiver:latest
 
 # NOTE: vodeo file extension does not matter.
 CMD bash -c '\


### PR DESCRIPTION
I updated the Kwiver docker image used for extracting the KLV metadata in the FMV datasets to use the latest release of Kwiver rather than a custom build.

(this has already been pushed to Dockerhub)