### PR TITLE
Load Bulma from a CDN, instead of vendoring it in the repo

### DIFF
--- a/rgd/core/static/css/style.css
+++ b/rgd/core/static/css/style.css
@@ -1,5 +1,3 @@
-@import url('dist/bulma.css');
-
 @import url('rgd/base.css'); /* fonts, links, headings, structure */
 @import url('rgd/transitions.css'); /* transition classes */
 

--- a/rgd/core/templates/base.html
+++ b/rgd/core/templates/base.html
@@ -3,6 +3,7 @@
   <head>
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.7.5/css/bulma.min.css" integrity="sha256-vK3UTo/8wHbaUn+dTQD0X6dzidqc5l7gczvH+Bnowwk=" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static 'css/style.css' %}" />
 
     <!-- Bootstrap CSS -->


### PR DESCRIPTION
The recent file reorganization resulted in the Bulma CSS file being excluded. Rather than re-adding it to the repo, it's more maintainable to load it from a CDN.