### PR TITLE
Backport changes from cookiecutter-django-girder v0.3

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -21,8 +21,9 @@ ENV PYTHONUNBUFFERED 1
 # but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
 # over top of this directory, the .egg-link in site-packages resolves to the mounted directory
 # and all package modules are importable.
-COPY ./setup.py /opt/django/setup.py
-WORKDIR /opt/django
+COPY ./setup.py /opt/django-project/setup.py
+# Use a directory name which will never be an import name, as isort considers this as first-party.
+WORKDIR /opt/django-project
 RUN pip install \
     --find-links https://girder.github.io/large_image_wheels \
     GDAL \

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,9 +5,11 @@ services:
       context: .
       dockerfile: ./dev/django.Dockerfile
     command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    # Log printing via Rich is enhanced by a TTY
+    tty: true
     env_file: ./dev/.env.docker-compose
     volumes:
-      - .:/opt/django
+      - .:/opt/django-project
     ports:
       - 8000:8000
     depends_on:
@@ -25,11 +27,13 @@ services:
       "--loglevel", "info",
       "--without-heartbeat"
     ]
+    # Docker Compose does not set the TTY width, which causes Celery errors
+    tty: false
     env_file: ./dev/.env.docker-compose
     environment:
       - TMPDIR=/tmp/rgd_worker
     volumes:
-      - .:/opt/django
+      - .:/opt/django-project
       - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
       - ${DOCKER_CMD:-/usr/bin/docker}:/usr/bin/docker
       - /tmp/rgd_worker:/tmp/rgd_worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
 
   minio:
     image: girder/minio-nonroot:latest
+    # When run with a TTY, minio prints credentials on startup
+    tty: true
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
     volumes:


### PR DESCRIPTION
https://github.com/girder/cookiecutter-django-girder/releases/tag/v0.3