### PR TITLE
Bump kwimage to remove torch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 # This is used by heroku for deployment
 --find-links https://girder.github.io/large_image_wheels
 GDAL
-# Heroku only uses CPU
-# See https://download.pytorch.org/whl/torch_stable.html for a list of wheels.
-https://download.pytorch.org/whl/cpu/torch-1.6.0%2Bcpu-cp38-cp38-linux_x86_64.whl
 # Install the app itself
 -e .[worker]

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,9 @@ setup(
             'fiona',
             'shapely',
             'scipy',
+            'kwarray>=0.5.10',
             'kwcoco',
-            'kwimage',
+            'kwimage>=0.6.7',
         ],
     },
 )


### PR DESCRIPTION
Jon Crall recently released a new version of `kwimage` and `kwarray` that makes `torch` and `pandas` optional dependencies. These changes should leverage that and significantly decrease the size of the virtual environment deployed on Heroku