### PR TITLE
Move video inside map UI layer for FMV detail page

### DIFF
--- a/rgd/geodata/templates/geodata/fmventry_detail.html
+++ b/rgd/geodata/templates/geodata/fmventry_detail.html
@@ -34,6 +34,10 @@
       let frameRate = JSON.parse('{{ frame_rate|escapejs }}');
       var video = document.getElementById("fmv_video");
 
+      // Move video to UI layer in map
+      var videoFrame = ui.createWidget('dom', {position: {left: 10, bottom: 10}});
+      videoFrame.canvas().appendChild(video)
+
       if (extents.ground_frames !== undefined) {
         let polys = JSON.parse(extents.ground_frames);
         let frameNumbers = extents.frame_numbers;

--- a/rgd/geodata/templates/geodata/fmventry_detail.html
+++ b/rgd/geodata/templates/geodata/fmventry_detail.html
@@ -42,9 +42,9 @@
         let polys = JSON.parse(extents.ground_frames);
         let frameNumbers = extents.frame_numbers;
 
-        var frameFootprint = layer.createFeature('polygon')
+        var frameFootprint = layer.createFeature('quad')
           .style({
-            fillColor: 'red',
+            color: 'red',
             opacity: 0.5
           })
 
@@ -53,13 +53,13 @@
           let index = frameNumbers.indexOf(frame);
           if (index > -1) {
             var coords = polys.coordinates[index][0]
-            var data = [[
-              {x: coords[0][0], y: coords[0][1]},
-              {x: coords[1][0], y: coords[1][1]},
-              {x: coords[2][0], y: coords[2][1]},
-              {x: coords[3][0], y: coords[3][1]},
-              {x: coords[4][0], y: coords[4][1]}
-            ]]
+            var data = [{
+              ll: {x: coords[0][0], y: coords[0][1]},
+              lr: {x: coords[1][0], y: coords[1][1]},
+              ur: {x: coords[2][0], y: coords[2][1]},
+              ul: {x: coords[3][0], y: coords[3][1]},
+              // video: video,
+            }]
 
             frameFootprint.data(data).draw();
           }


### PR DESCRIPTION
This is a minor change to move the FMV video onto the GeoJS map's UI layer.

<img width="1119" alt="Screen Shot 2020-10-28 at 10 25 35 AM" src="https://user-images.githubusercontent.com/22067021/97465926-2ec49500-1908-11eb-9a49-b8a7db42e975.png">


We cannot display the video over the red marker because it is a polygon. AFAIK, only quads support overlain video -- we cannot use a quad here because the video frame's projection on the ground is typically a trapezoid