### PR TITLE
Add faceted search

### DIFF
--- a/rgd/geodata/api/__init__.py
+++ b/rgd/geodata/api/__init__.py
@@ -1,0 +1,9 @@
+"""Views for the API.
+
+Views routed under `/api/geodata`. The primary `Content-Type` recieved and served
+by these views ought to be `application/json`.
+"""
+
+__all__ = ['download', 'search']
+
+from . import download, search

--- a/rgd/geodata/api/download.py
+++ b/rgd/geodata/api/download.py
@@ -1,0 +1,39 @@
+import os
+
+from django.db.models.fields.files import FieldFile
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404  # , render
+from django.utils.encoding import smart_str
+from drf_yasg2.utils import swagger_auto_schema
+from rest_framework.decorators import api_view
+
+from rgd.geodata import models
+
+
+@swagger_auto_schema(
+    method='GET',
+    operation_summary='Download a model file',
+    operation_description='Download a model file through the server instead of from the assetstore',
+)
+@api_view(['GET'])
+def download_file(request, model, id, field):
+    model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])
+    if not hasattr(models, model_class):
+        raise Exception('No such model (%s)' % model)
+    model_inst = get_object_or_404(getattr(models, model_class), pk=id)
+    if not isinstance(getattr(model_inst, field, None), FieldFile):
+        raise Exception('No such file (%s)' % field)
+    file = getattr(model_inst, field)
+    filename = os.path.basename(file.name)
+    if not filename:
+        filename = '%s_%s_%s.dat' % (model, id, field)
+    mimetype = getattr(
+        model_inst,
+        '%s_mimetype' % field,
+        'text/plain' if field == 'log' else 'application/octet-stream',
+    )
+    response = HttpResponse(file.chunks(), content_type=mimetype)
+    response['Content-Disposition'] = smart_str(u'attachment; filename=%s' % filename)
+    if len(file) is not None:
+        response['Content-Length'] = len(file)
+    return response

--- a/rgd/geodata/api/search.py
+++ b/rgd/geodata/api/search.py
@@ -15,10 +15,9 @@ from rest_framework import serializers as rfserializers
 from rest_framework.decorators import api_view
 from rest_framework.generics import ListAPIView
 
-from . import serializers
-from .filters import SpatialEntryFilter
-from .models import GeometryEntry, RasterMetaEntry, SpatialEntry
-from .serializers import SpatialEntrySerializer
+from rgd.geodata import serializers
+from rgd.geodata.filters import SpatialEntryFilter
+from rgd.geodata.models import GeometryEntry, RasterMetaEntry, SpatialEntry
 
 
 class NearPointSerializer(rfserializers.Serializer):
@@ -580,6 +579,6 @@ def search_geojson_extent_geometry(request, *args, **kwargs):
 
 class SearchSpatialEntryView(ListAPIView):
     queryset = SpatialEntry.objects.all()
-    serializer_class = SpatialEntrySerializer
+    serializer_class = serializers.SpatialEntrySerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = SpatialEntryFilter

--- a/rgd/geodata/filters.py
+++ b/rgd/geodata/filters.py
@@ -1,0 +1,270 @@
+from django.contrib.gis import forms
+from django.contrib.gis.db.models.functions import GeometryDistance
+from django.contrib.gis.measure import D
+from django.core.validators import RegexValidator
+from django.db.models import Q, Sum
+from django_filters import rest_framework as filters
+
+from rgd.geodata.models.common import SpatialEntry
+
+
+class GeometryFilter(filters.Filter):
+    field_class = forms.GeometryField
+
+
+class SpatialEntryFilter(filters.FilterSet):
+
+    q = GeometryFilter(
+        help_text='A Well-known text (WKT) representation of a geometry or a GeoJSON.',
+        label='WKT/GeoJSON',
+        method='filter_q',
+    )
+    predicate = filters.ChoiceFilter(
+        choices=(
+            ('contains', 'contains'),
+            ('crosses', 'crosses'),
+            ('disjoint', 'disjoint'),
+            ('equals', 'equals'),
+            ('intersects', 'intersects'),
+            ('overlaps', 'overlaps'),
+            ('touches', 'touches'),
+            ('within', 'within'),
+        ),
+        help_text=(
+            'A named spatial predicate based on the DE-9IM. This spatial predicate will be used '
+            'to filter data such that `predicate(a, b)` where `b` is the queried geometry.'
+        ),
+        label='Spatial predicate',
+        method='filter_predicate',
+    )
+    relates = filters.CharFilter(
+        help_text=(
+            'Specify exactly how the queried geometry should relate to the data using a DE-9IM '
+            'string code.'
+        ),
+        label='DE-9IM string code',
+        max_length=9,
+        method='filter_relates',
+        min_length=9,
+        validators=(
+            RegexValidator(regex=r'^[\*012TF]{9}$', message='Enter a valid DE-9IM string code.'),
+        ),
+    )
+    distance = filters.RangeFilter(
+        help_text='The minimum/maximum distance around the queried geometry in meters.',
+        label='Distance',
+        method='filter_distance',
+    )
+    acquired = filters.IsoDateTimeFromToRangeFilter(
+        field_name='acquisition_date',
+        help_text='The ISO 8601 formatted date and time when data was acquired.',
+        label='Acquired',
+        method='filter_acquired',
+    )
+    created = filters.IsoDateTimeFromToRangeFilter(
+        field_name='created',
+        help_text='The ISO 8601 formatted date and time when data was created.',
+        label='Created',
+        method='filter_created',
+    )
+    modified = filters.IsoDateTimeFromToRangeFilter(
+        field_name='modified',
+        help_text='The ISO 8601 formatted date and time when data was modified.',
+        label='Modified',
+        method='filter_modified',
+    )
+    datatype = filters.ChoiceFilter(
+        choices=(
+            ('raster', 'raster'),
+            ('fmv', 'fmv'),
+            ('geometry', 'geometry'),
+        ),
+        help_text='The datatype to provide.',
+        method='filter_datatype',
+        label='Datatype',
+    )
+    instrumentation = filters.CharFilter(
+        field_name='rastermetaentry__parent_raster__image_set__images__instrumentation',
+        help_text='The instrumentation used to acquire at least one of these data.',
+        label='Instrumentation',
+        lookup_expr='icontains',
+    )
+    num_bands = filters.RangeFilter(
+        fields=(forms.IntegerField(), forms.IntegerField()),
+        help_text='The number of bands in the raster.',
+        method='filter_bands',
+        label='Number of bands',
+    )
+    resolution = filters.RangeFilter(
+        fields=(forms.IntegerField(), forms.IntegerField()),
+        help_text='The resolution of the raster.',
+        label='Resolution',
+        method='filter_resolution',
+    )
+    frame_rate = filters.RangeFilter(
+        field_name='fmv_entry__fmv_file',
+        fields=(forms.IntegerField(), forms.IntegerField()),
+        help_text='The frame rate of the video.',
+        label='Frame rate',
+    )
+
+    def filter_q(self, queryset, name, value):
+        """Sort the queryset by distance to queried geometry.
+
+        Annotates the queryset with `distance`.
+
+        This uses the efficient KNN operation:
+        https://postgis.net/docs/geometry_distance_knn.html
+        """
+        return queryset.annotate(distance=GeometryDistance('footprint', value)).order_by('distance')
+
+    def filter_predicate(self, queryset, name, value):
+        """Filter the spatial entries by the chosen predicate."""
+        if value is not None:
+            geom = self.form.cleaned_data['q']
+            return queryset.filter(**{f'footprint__{value}': geom})
+        return queryset
+
+    def filter_relates(self, queryset, name, value):
+        """Filter the spatial entries by the chosen DE-9IM."""
+        if value is not None:
+            geom = self.form.cleaned_data['q']
+            return queryset.filter(footprint__relates=(geom, value))
+        return queryset
+
+    def filter_distance(self, queryset, name, value):
+        """Filter the queryset by distance to the queried geometry.
+
+        We may wish to use the distance in degrees later on. This is
+        very taxing on the DBMS right now. The distance in degrees
+        can be provided by the initial geometry query.
+        """
+        if value:
+            geom = self.form.cleaned_data['q']
+            if value.start is not None:
+                queryset = queryset.filter(footprint__distance_gte=(geom, D(m=value.start)))
+            if value.stop is not None:
+                queryset = queryset.filter(footprint__distance_lte=(geom, D(m=value.stop)))
+            return queryset
+
+    def filter_datatype(self, queryset, name, value):
+        """Filter the `SpatialEntry`s to a specific datatype."""
+        if value == 'geometry':
+            return queryset.filter(geometryentry__isnull=False)
+        if value == 'raster':
+            return queryset.filter(rasterentrymeta__isnull=False)
+        if value == 'fmv':
+            return queryset.filter(fmventry__isnull=False)
+        return queryset
+
+    def filter_acquired(self, queryset, name, value):
+        """Filter by when the data was acquired.
+
+        There is a special where filtering by acquisition, created is also filtered
+        for `RasterEntry`.
+        """
+        if value:
+            if value.start is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(acquisition_date__gte=value)
+                        | Q(rasterentrymeta__parent_raster__created=value)
+                    )
+                )
+            if value.stop is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(acquisition_date__gte=value)
+                        | Q(rasterentrymeta__parent_raster__created=value)
+                    )
+                )
+        return queryset
+
+    def filter_created(self, queryset, name, value):
+        """Filter by when the data was created."""
+        if value:
+            if value.start is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(geometryentry__parent_raster__created__gte=value)
+                        | Q(fmventry__created__gte=value)
+                        | Q(rasterentrymeta__parent_raster__created__gte=value)
+                    )
+                )
+            if value.stop is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(geometryentry__parent_raster__created__lte=value)
+                        | Q(fmventry__created__lte=value)
+                        | Q(rasterentrymeta__parent_raster__created__lte=value)
+                    )
+                )
+        return queryset
+
+    def filter_modified(self, queryset, name, value):
+        """Filter by when the data was modified."""
+        if value:
+            if value.start is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(geometryentry__parent_raster__modified__gte=value)
+                        | Q(fmventry__modified__gte=value)
+                        | Q(rasterentrymeta__parent_raster__modified__gte=value)
+                    )
+                )
+            if value.stop is not None:
+                queryset = queryset.filter(
+                    (
+                        Q(geometryentry__parent_raster__modified__lte=value)
+                        | Q(fmventry__modified__lte=value)
+                        | Q(rasterentrymeta__parent_raster__modified__lte=value)
+                    )
+                )
+        return queryset
+
+    def filter_bands(self, queryset, name, value):
+        """Filter by the total number of bands in the raster data.
+
+        Annotates the queryset with `num_bands`.
+        """
+        if value is not None:
+            queryset = queryset.annotate(
+                num_bands=Sum('rastermetaentry__parent_raster__image_set__images__number_of_bands')
+            )
+            if value.start is not None:
+                queryset = queryset.filter(num_bands__gte=value.start)
+            if value.stop is not None:
+                queryset = queryset.filter(num_bands__lte=value.stop)
+        return queryset
+
+    def filter_resolution(self, queryset, name, value):
+        """Filter by the resolution in the raster data."""
+        if value is not None:
+            if value.start is not None:
+                queryset = queryset.filter(
+                    Q(rastermetaentry__resolution__0__gte=value.start)
+                    & Q(rastermetaentry__resolution__1__gte=value.start)
+                )
+            if value.stop is not None:
+                queryset = queryset.filter(
+                    Q(rastermetaentry__resolution__0__lte=value.stop)
+                    & Q(rastermetaentry__resolution__1__lte=value.stop)
+                )
+        return queryset
+
+    class Meta:
+        model = SpatialEntry
+        fields = [
+            'q',
+            'predicate',
+            'relates',
+            'distance',
+            'acquired',
+            'created',
+            'modified',
+            'datatype',
+            'instrumentation',
+            'num_bands',
+            'resolution',
+            'frame_rate',
+        ]

--- a/rgd/geodata/search.py
+++ b/rgd/geodata/search.py
@@ -9,12 +9,16 @@ from django.db.models import Max, Min, Q
 from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
 from django.utils.timezone import make_aware
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg2.utils import swagger_auto_schema
 from rest_framework import serializers as rfserializers
 from rest_framework.decorators import api_view
+from rest_framework.generics import ListAPIView
 
 from . import serializers
+from .filters import SpatialEntryFilter
 from .models import GeometryEntry, RasterMetaEntry, SpatialEntry
+from .serializers import SpatialEntrySerializer
 
 
 class NearPointSerializer(rfserializers.Serializer):
@@ -572,3 +576,10 @@ def search_geojson_extent_geometry(request, *args, **kwargs):
     params = request.query_params
     found = GeometryEntry.objects.filter(search_geojson_filter(params))
     return extent_summary_http(found)
+
+
+class SearchSpatialEntryView(ListAPIView):
+    queryset = SpatialEntry.objects.all()
+    serializer_class = SpatialEntrySerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = SpatialEntryFilter

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from django.views.generic.base import RedirectView
 
-from . import search, views
+from . import api, views
 
 urlpatterns = [
     # Pages
@@ -35,25 +35,29 @@ urlpatterns = [
     ),
     # API
     path(
-        'api/geodata/download/<model>/<int:id>/<field>', views.download_file, name='download-file'
+        'api/geodata/download/<model>/<int:id>/<field>',
+        api.download.download_file,
+        name='download-file',
     ),
-    path('api/geodata/near_point', search.search_near_point),
-    path('api/geodata/raster/near_point', search.search_near_point_raster),
-    path('api/geodata/geometry/near_point', search.search_near_point_geometry),
-    path('api/geodata/near_point/extent', search.search_near_point_extent),
-    path('api/geodata/raster/near_point/extent', search.search_near_point_extent_raster),
-    path('api/geodata/geometry/near_point/extent', search.search_near_point_extent_geometry),
-    path('api/geodata/bounding_box', search.search_bounding_box),
-    path('api/geodata/raster/bounding_box', search.search_bounding_box_raster),
-    path('api/geodata/geometry/bounding_box', search.search_bounding_box_geometry),
-    path('api/geodata/bounding_box/extent', search.search_bounding_box_extent),
-    path('api/geodata/raster/bounding_box/extent', search.search_bounding_box_extent_raster),
-    path('api/geodata/geometry/bounding_box/extent', search.search_bounding_box_extent_geometry),
-    path('api/geodata/geojson', search.search_geojson),
-    path('api/geodata/raster/geojson', search.search_geojson_raster),
-    path('api/geodata/geometry/geojson', search.search_geojson_geometry),
-    path('api/geodata/geojson/extent', search.search_geojson_extent),
-    path('api/geodata/raster/geojson/extent', search.search_geojson_extent_raster),
-    path('api/geodata/geometry/geojson/extent', search.search_geojson_extent_geometry),
-    path('api/geodata/search', search.SearchSpatialEntryView.as_view()),
+    path('api/geodata/near_point', api.search.search_near_point),
+    path('api/geodata/raster/near_point', api.search.search_near_point_raster),
+    path('api/geodata/geometry/near_point', api.search.search_near_point_geometry),
+    path('api/geodata/near_point/extent', api.search.search_near_point_extent),
+    path('api/geodata/raster/near_point/extent', api.search.search_near_point_extent_raster),
+    path('api/geodata/geometry/near_point/extent', api.search.search_near_point_extent_geometry),
+    path('api/geodata/bounding_box', api.search.search_bounding_box),
+    path('api/geodata/raster/bounding_box', api.search.search_bounding_box_raster),
+    path('api/geodata/geometry/bounding_box', api.search.search_bounding_box_geometry),
+    path('api/geodata/bounding_box/extent', api.search.search_bounding_box_extent),
+    path('api/geodata/raster/bounding_box/extent', api.search.search_bounding_box_extent_raster),
+    path(
+        'api/geodata/geometry/bounding_box/extent', api.search.search_bounding_box_extent_geometry
+    ),
+    path('api/geodata/geojson', api.search.search_geojson),
+    path('api/geodata/raster/geojson', api.search.search_geojson_raster),
+    path('api/geodata/geometry/geojson', api.search.search_geojson_geometry),
+    path('api/geodata/geojson/extent', api.search.search_geojson_extent),
+    path('api/geodata/raster/geojson/extent', api.search.search_geojson_extent_raster),
+    path('api/geodata/geometry/geojson/extent', api.search.search_geojson_extent_geometry),
+    path('api/geodata/search', api.search.SearchSpatialEntryView.as_view()),
 ]

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -55,4 +55,5 @@ urlpatterns = [
     path('api/geodata/geojson/extent', search.search_geojson_extent),
     path('api/geodata/raster/geojson/extent', search.search_geojson_extent_raster),
     path('api/geodata/geometry/geojson/extent', search.search_geojson_extent_geometry),
+    path('api/geodata/search', search.SearchSpatialEntryView.as_view()),
 ]

--- a/rgd/geodata/views.py
+++ b/rgd/geodata/views.py
@@ -1,16 +1,9 @@
 import json
-import os
 
-from django.db.models.fields.files import FieldFile
-from django.http import HttpResponse
-from django.shortcuts import get_object_or_404  # , render
-from django.utils.encoding import smart_str
 from django.views import generic
 from django.views.generic import DetailView
-from drf_yasg2.utils import swagger_auto_schema
-from rest_framework.decorators import api_view
 
-from . import models, search
+from .api import search
 from .models.common import SpatialEntry
 from .models.fmv.base import FMVEntry
 from .models.geometry import GeometryEntry
@@ -159,32 +152,3 @@ class GeometryEntryDetailView(_SpatialDetailView):
 
 class SpatialEntryDetailView(_SpatialDetailView):
     model = SpatialEntry
-
-
-@swagger_auto_schema(
-    method='GET',
-    operation_summary='Download a model file',
-    operation_description='Download a model file through the server instead of from the assetstore',
-)
-@api_view(['GET'])
-def download_file(request, model, id, field):
-    model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])
-    if not hasattr(models, model_class):
-        raise Exception('No such model (%s)' % model)
-    model_inst = get_object_or_404(getattr(models, model_class), pk=id)
-    if not isinstance(getattr(model_inst, field, None), FieldFile):
-        raise Exception('No such file (%s)' % field)
-    file = getattr(model_inst, field)
-    filename = os.path.basename(file.name)
-    if not filename:
-        filename = '%s_%s_%s.dat' % (model, id, field)
-    mimetype = getattr(
-        model_inst,
-        '%s_mimetype' % field,
-        'text/plain' if field == 'log' else 'application/octet-stream',
-    )
-    response = HttpResponse(file.chunks(), content_type=mimetype)
-    response['Content-Disposition'] = smart_str(u'attachment; filename=%s' % filename)
-    if len(file) is not None:
-        response['Content-Length'] = len(file)
-    return response


### PR DESCRIPTION
This simply adds the [django-filter](https://django-filter.readthedocs.io/en/stable/) based faceted search API endpoint at `api/geodata/search`.

- `q`: geometry (sorts sets by NN)
- `predicate`: DE-9IM spatial predicate
- `relates`: DE-9IM string
- `distance` (min/max)
- `acquired` (min/max)
- `created` (min/max)
- `modified` (min/max)
- `datatype`: choice of raster, geometry, or FMV
- `instrumentation` (search with `icontains`)
- `num_bands` (min/max)
- `resolution` (min/max)
- `frame_rate` (min/max)

I can see a way where this could replace the [`search.py`](https://github.com/ResonantGeoData/ResonantGeoData/blob/master/rgd/geodata/search.py) module entirely. I had been working on implementing the GUI for this, but the code duplication was getting a bit out of hand. Instead, I am working on a single `SpatialEntryViewSet` using this filter. The drop-downs for GeoJSON, point, and bbox can all be implemented as widgets to populate `q`. However, this GUI based work is taking a back-burner on to-do in order to get permissions down before Dec 1.