### PR TITLE
Remove unused style

### DIFF
--- a/rgd/core/static/css/style.css
+++ b/rgd/core/static/css/style.css
@@ -1,9 +1,0 @@
-@import url('rgd/base.css'); /* fonts, links, headings, structure */
-@import url('rgd/transitions.css'); /* transition classes */
-
-@import url('rgd/account.css'); /* login/logout styles */
-/* @import url('rgd/dashboard.css'); /* dashboard styles */
-/* @import url('rgd/submission-details.css'); /* submission detail styles */
-/* @import url('rgd/submission-wizard.css'); /* submission wizard styles */
-/* @import url('rgd/task_dashboard.css'); /* task dashboard styles */
-/* @import url('rgd/joist.css');


### PR DESCRIPTION
Resolve #210: I believe this should do it.

https://github.com/ResonantGeoData/ResonantGeoData/issues/210#issuecomment-744507473 outlines that this file is throwing the error as it is looking for stylesheets that do not exist. Upon inspection, this file isn't even needed as the templates in the `core` app pull `style.css` which should pull from `geodata` since that app is set up correctly.

Also, the `core` app is entirely disabled on the frontend so we shouldn't need any static resources for it.