### PR TITLE
Use get_or_create in serializer

### DIFF
--- a/rgd/geodata/management/commands/demo_data.py
+++ b/rgd/geodata/management/commands/demo_data.py
@@ -118,13 +118,7 @@ class Command(BaseCommand):
                     imset.images.add(image)
                 imset.save()
             # Make raster of that image set
-            # Check if raster exists with that ImageSet
-            try:
-                raster = models.RasterEntry.objects.get(image_set__pk=imset.pk)
-            except models.RasterEntry.DoesNotExist:
-                raster = models.RasterEntry()
-                raster.image_set = imset
-                raster.save()
+            raster = models.RasterEntry.objects.get_or_create(image_set=imset)
             ids.append(raster.pk)
         return ids
 

--- a/rgd/geodata/models/fmv/etl.py
+++ b/rgd/geodata/models/fmv/etl.py
@@ -11,6 +11,8 @@ import docker
 from girder_utils.files import field_file_to_local_path
 import numpy as np
 
+from rgd.utility import get_or_create_no_commit
+
 from .base import FMVEntry, FMVFile
 
 logger = get_task_logger(__name__)
@@ -242,17 +244,9 @@ def read_fmv_file(fmv_file_id):
         _convert_video_to_mp4(fmv_file)
 
     # create a model entry for that shapefile
-    entry_query = FMVEntry.objects.filter(fmv_file=fmv_file_id)
-    if len(entry_query) < 1:
-        entry = FMVEntry()
-        # geometry_entry.creator = archive.creator
-        entry.name = fmv_file.name
-        entry.fmv_file = fmv_file
-    elif len(entry_query) == 1:
-        entry = entry_query.first()
-    else:
-        # This should never happen because it is a foreign key
-        raise RuntimeError('multiple FMV entries found for this file.')  # pragma: no cover
+    entry, created = get_or_create_no_commit(
+        FMVEntry, defaults=dict(name=fmv_file.name), fmv_file=fmv_file
+    )
 
     _populate_fmv_entry(entry)
     entry.save()

--- a/rgd/geodata/models/imagery/etl.py
+++ b/rgd/geodata/models/imagery/etl.py
@@ -16,7 +16,6 @@ from django.contrib.gis.geos import (
     Point,
     Polygon,
 )
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from girder_utils.files import field_file_to_local_path
 import kwcoco
@@ -28,6 +27,8 @@ import rasterio
 import rasterio.features
 import rasterio.warp
 from rasterio.warp import Resampling, calculate_default_transform, reproject
+
+from rgd.utility import get_or_create_no_commit
 
 from ..constants import DB_SRID, WEB_MERCATOR
 from .annotation import Annotation, PolygonSegmentation, RLESegmentation, Segmentation
@@ -125,17 +126,7 @@ def _reproject_raster(src, epsg):
 
 def _read_image_to_entry(image_entry, image_file_path):
 
-    thumbnail_query = Thumbnail.objects.filter(image_entry=image_entry)
-    if len(thumbnail_query) < 1:
-        thumbnail = Thumbnail()
-        # image_entry.creator = ife.creator
-    elif len(thumbnail_query) == 1:
-        thumbnail = thumbnail_query.first()
-    else:
-        # This should never happen because it is a OneToOneField
-        raise RuntimeError('multiple thumbnail entries found for this image.')  # pragma: no cover
-
-    thumbnail.image_entry = image_entry
+    thumbnail, created = get_or_create_no_commit(Thumbnail, image_entry=image_entry)
 
     with rasterio.open(image_file_path) as src:
         image_entry.number_of_bands = src.count
@@ -209,22 +200,15 @@ def populate_image_entry(ife):
 
     with field_file_to_local_path(ife.file) as file_path:
         logger.info(f'The image file path: {file_path}')
-        image_query = ImageEntry.objects.filter(image_file=ife)
-        if len(image_query) < 1:
-            image_entry = ImageEntry()
-            image_entry.name = ife.name
-            # image_entry.creator = ife.creator
-        elif len(image_query) == 1:
-            image_entry = image_query.first()
+
+        image_entry, created = get_or_create_no_commit(
+            ImageEntry, defaults=dict(name=ife.name), image_file=ife
+        )
+        if not created:
             # Clear out associated entries because they could be invalid
             BandMetaEntry.objects.filter(parent_image=image_entry).delete()
             ConvertedImageFile.objects.filter(source_image=image_entry).delete()
-        else:
-            # This should never happen because it is a foreign key
-            raise RuntimeError('multiple image entries found for this file.')  # pragma: no cover
 
-        image_entry.image_file = ife
-        # image_entry.modifier = ife.modifier
         _read_image_to_entry(image_entry, file_path)
 
     return image_entry
@@ -360,11 +344,8 @@ def populate_raster_entry(raster_id):
                 'name',
             ]
         )
-    try:
-        raster_meta = raster_entry.rastermetaentry
-    except ObjectDoesNotExist:
-        raster_meta = RasterMetaEntry()
-        raster_meta.parent_raster = raster_entry
+    raster_meta, created = get_or_create_no_commit(RasterMetaEntry, parent_raster=raster_entry)
+    # Not using `defaults` here because we want `meta` to always get updated.
     for k, v in meta.items():
         # Yeah. This is sketchy, but it works.
         setattr(raster_meta, k, v)

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -84,23 +84,10 @@ class SubsampledImageSerializer(serializers.ModelSerializer):
         ]
 
     def create(self, validated_data):
-        """Prevent duplicated subsamples from being created.
-
-        This will check to see if an existing model matches the
-        ``sample_parameters`` for the given image ID and return that object
-        instead of creating another.
-
-        """
-        sample_parameters = validated_data['sample_parameters']
-        source_image = validated_data['source_image']
-        q = models.SubsampledImage.objects.filter(
-            sample_parameters=sample_parameters, source_image=source_image
-        )
-        if q.count() == 0:
-            obj = models.SubsampledImage.objects.create(**validated_data)
-        else:
-            obj = q.first()
-            # Trigger a reprocessing
+        """Prevent duplicated subsamples from being created."""
+        obj, created = models.SubsampledImage.objects.get_or_create(**validated_data)
+        if not created:
+            # Trigger save event to reprocess the subsampling
             obj.save()
         return obj
 

--- a/rgd/utility.py
+++ b/rgd/utility.py
@@ -131,3 +131,13 @@ def make_serializers(serializer_scope, models):
             serializer_name = serializer_class.__name__
             if serializer_name not in serializer_scope:
                 serializer_scope[serializer_name] = serializer_class
+
+
+def get_or_create_no_commit(model, defaults=None, **kwargs):
+    try:
+        return model.objects.get(**kwargs), False
+    except model.DoesNotExist:
+        if not defaults:
+            defaults = {}
+        defaults.update(kwargs)
+        return model(**defaults), True


### PR DESCRIPTION
Quick patch to make code cleaner/better and use functionality already exists in django

Follow up to #236 

-----

While I was at it, I cleaned up a few other places in the ETL routines where this logic was used and added a new `get_or_create_no_commit` helper for doing the same thing without automatically saving to the DB.