### PR TITLE
Use authenticated API client

### DIFF
--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -52,48 +52,48 @@ def landsat_raster():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_download_file(client, arbitrary_file):
+def test_download_file(api_client, arbitrary_file):
     model = 'ArbitraryFile'
     id = arbitrary_file.id
     field = 'file'
-    response = client.get(f'/api/geodata/download/{model}/{id}/{field}')
+    response = api_client.get(f'/api/geodata/download/{model}/{id}/{field}')
     assert response.status_code == 200, response.content
     with pytest.raises(AttributeError):
         # Test bad model
-        client.get('/api/geodata/download/Foo/0/file')
+        api_client.get('/api/geodata/download/Foo/0/file')
     with pytest.raises(AttributeError):
         # Test good model, bad field
-        client.get(f'/api/geodata/download/{model}/{id}/foo')
+        api_client.get(f'/api/geodata/download/{model}/{id}/foo')
 
 
 @pytest.mark.django_db(transaction=True)
-def test_get_status(client, astro_image):
+def test_get_status(api_client, astro_image):
     model = 'ImageFile'
     id = astro_image.image_file.imagefile.id
-    response = client.get(f'/api/geodata/status/{model}/{id}')
+    response = api_client.get(f'/api/geodata/status/{model}/{id}')
     assert response.status_code == 200, response.content
     with pytest.raises(AttributeError):
-        client.get(f'/api/geodata/status/Foo/{id}')
+        api_client.get(f'/api/geodata/status/Foo/{id}')
 
 
 @pytest.mark.django_db(transaction=True)
-def test_download_arbitry_file(client, arbitrary_file):
+def test_download_arbitry_file(api_client, arbitrary_file):
     pk = arbitrary_file.pk
-    response = client.get(f'/api/geodata/common/arbitrary_file/{pk}/data')
+    response = api_client.get(f'/api/geodata/common/arbitrary_file/{pk}/data')
     assert response.status_code == 302 or response.status_code == 200, response.content
 
 
 @pytest.mark.django_db(transaction=True)
-def test_download_image_entry_file(client, astro_image):
+def test_download_image_entry_file(api_client, astro_image):
     pk = astro_image.pk
-    response = client.get(f'/api/geodata/imagery/image_entry/{pk}/data')
+    response = api_client.get(f'/api/geodata/imagery/image_entry/{pk}/data')
     assert response.status_code == 302 or response.status_code == 200, response.content
 
 
 @pytest.mark.django_db(transaction=True)
-def test_get_arbitrary_file(client, arbitrary_file):
+def test_get_arbitrary_file(api_client, arbitrary_file):
     pk = arbitrary_file.pk
-    content = json.loads(client.get(f'/api/geodata/common/arbitrary_file/{pk}').content)
+    content = json.loads(api_client.get(f'/api/geodata/common/arbitrary_file/{pk}').content)
     assert content
     # Check that a hyperlink is given to the file data
     # NOTE: tried using the URLValidator from django but it thinks this URL is invalid
@@ -101,10 +101,10 @@ def test_get_arbitrary_file(client, arbitrary_file):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_get_spatial_entry(client, landsat_raster):
+def test_get_spatial_entry(api_client, landsat_raster):
     """Test individual GET for SpatialEntry model."""
     pk = landsat_raster.rastermetaentry.spatial_id
-    response = client.get(f'/api/geodata/common/spatial_entry/{pk}')
+    response = api_client.get(f'/api/geodata/common/spatial_entry/{pk}')
     assert response.status_code == 200, response.content
     content = json.loads(response.content)
     assert content

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -115,23 +115,22 @@ def test_get_spatial_entry(client, landsat_raster):
 @pytest.mark.django_db(transaction=True)
 def test_create_get_subsampled_image(authenticated_api_client, astro_image):
     """Test POST and GET for SubsampledImage model."""
-    client = authenticated_api_client
     payload = {
         'source_image': astro_image.pk,
         'sample_type': 'pixel box',
         'sample_parameters': json.dumps({'umax': 100, 'umin': 0, 'vmax': 200, 'vmin': 0}),
     }
-    response = client.post('/api/geodata/imagery/subsample', payload)
+    response = authenticated_api_client.post('/api/geodata/imagery/subsample', payload)
     assert response.status_code == 201, response.content
     content = json.loads(response.content)
     pk = content['pk']
     sub = models.imagery.SubsampledImage.objects.get(pk=pk)
     assert sub.data
     # Test the GET
-    response = client.get(f'/api/geodata/imagery/subsample/{pk}')
+    response = authenticated_api_client.get(f'/api/geodata/imagery/subsample/{pk}')
     assert response.status_code == 200, response.content
     # Now test to make sure the serializer prevents duplicates
-    response = client.post('/api/geodata/imagery/subsample', payload)
+    response = authenticated_api_client.post('/api/geodata/imagery/subsample', payload)
     assert response.status_code == 201, response.content
     content = json.loads(response.content)
     assert pk == content['pk']  # Compare against original PK
@@ -140,8 +139,7 @@ def test_create_get_subsampled_image(authenticated_api_client, astro_image):
 @pytest.mark.django_db(transaction=True)
 def test_create_and_download_cog(authenticated_api_client, landsat_image):
     """Test POST for ConvertedImageFile model."""
-    client = authenticated_api_client
-    response = client.post(
+    response = authenticated_api_client.post(
         '/api/geodata/imagery/cog',
         {'source_image': landsat_image.id},
     )
@@ -152,5 +150,5 @@ def test_create_and_download_cog(authenticated_api_client, landsat_image):
     assert cog.converted_file
     # Also test download endpoint here:
     pk = cog.pk
-    response = client.get(f'/api/geodata/imagery/cog/{pk}/data')
+    response = authenticated_api_client.get(f'/api/geodata/imagery/cog/{pk}/data')
     assert response.status_code == 302 or response.status_code == 200, response.content

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -113,8 +113,9 @@ def test_get_spatial_entry(client, landsat_raster):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_create_get_subsampled_image(client, astro_image):
+def test_create_get_subsampled_image(authenticated_api_client, astro_image):
     """Test POST and GET for SubsampledImage model."""
+    client = authenticated_api_client
     payload = {
         'source_image': astro_image.pk,
         'sample_type': 'pixel box',
@@ -137,8 +138,9 @@ def test_create_get_subsampled_image(client, astro_image):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_create_and_download_cog(client, landsat_image):
+def test_create_and_download_cog(authenticated_api_client, landsat_image):
     """Test POST for ConvertedImageFile model."""
+    client = authenticated_api_client
     response = client.post(
         '/api/geodata/imagery/cog',
         {'source_image': landsat_image.id},

--- a/rgd/geodata/tests/test_search.py
+++ b/rgd/geodata/tests/test_search.py
@@ -34,30 +34,30 @@ def _load_sample_files():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_near_point(client):
+def test_search_near_point(api_client):
     _load_sample_files()
-    items = json.loads(client.get('/api/geodata/near_point').content)
+    items = json.loads(api_client.get('/api/geodata/near_point').content)
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get('/api/geodata/near_point', {'longitude': -79, 'latitude': 43}).content
+        api_client.get('/api/geodata/near_point', {'longitude': -79, 'latitude': 43}).content
     )
     assert len(items) == 1
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/near_point', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
         ).content
     )
     assert len(items) == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/near_point',
             {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
         ).content
     )
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/near_point',
             {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
         ).content
@@ -66,30 +66,30 @@ def test_search_near_point(client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_near_point_extent(client):
+def test_search_near_point_extent(api_client):
     _load_sample_files()
-    results = json.loads(client.get('/api/geodata/near_point/extent').content)
+    results = json.loads(api_client.get('/api/geodata/near_point/extent').content)
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get('/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43}).content
+        api_client.get('/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43}).content
     )
     assert results['count'] == 1
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
         ).content
     )
     assert results['count'] == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/near_point/extent',
             {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
         ).content
     )
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/near_point/extent',
             {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
         ).content
@@ -98,12 +98,12 @@ def test_search_near_point_extent(client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_bounding_box(client):
+def test_search_bounding_box(api_client):
     _load_sample_files()
-    items = json.loads(client.get('/api/geodata/bounding_box').content)
+    items = json.loads(api_client.get('/api/geodata/bounding_box').content)
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/bounding_box',
             {
                 'minimum_longitude': -80,
@@ -115,7 +115,7 @@ def test_search_bounding_box(client):
     )
     assert len(items) == 1
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/bounding_box',
             {
                 'minimum_longitude': -90,
@@ -131,14 +131,14 @@ def test_search_bounding_box(client):
         '%Y-%m-%d %H:%M:%S'
     )
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/bounding_box',
             {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
     )
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/bounding_box',
             {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
@@ -147,12 +147,12 @@ def test_search_bounding_box(client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_bounding_box_extent(client):
+def test_search_bounding_box_extent(api_client):
     _load_sample_files()
-    results = json.loads(client.get('/api/geodata/bounding_box/extent').content)
+    results = json.loads(api_client.get('/api/geodata/bounding_box/extent').content)
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/bounding_box/extent',
             {
                 'minimum_longitude': -80,
@@ -164,7 +164,7 @@ def test_search_bounding_box_extent(client):
     )
     assert results['count'] == 1
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/bounding_box/extent',
             {
                 'minimum_longitude': -90,
@@ -180,14 +180,14 @@ def test_search_bounding_box_extent(client):
         '%Y-%m-%d %H:%M:%S'
     )
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/bounding_box/extent',
             {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
     )
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/bounding_box/extent',
             {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
@@ -196,12 +196,12 @@ def test_search_bounding_box_extent(client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_geojson(client):
+def test_search_geojson(api_client):
     _load_sample_files()
-    items = json.loads(client.get('/api/geodata/geojson').content)
+    items = json.loads(api_client.get('/api/geodata/geojson').content)
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/geojson',
             {
                 'geojson': json.dumps(
@@ -215,7 +215,7 @@ def test_search_geojson(client):
     )
     assert len(items) == 1
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/geojson',
             {
                 'geojson': json.dumps(
@@ -233,14 +233,14 @@ def test_search_geojson(client):
         '%Y-%m-%d %H:%M:%S'
     )
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/geojson',
             {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
     )
     assert len(items) == len(SampleFiles)
     items = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/geojson',
             {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
@@ -249,12 +249,12 @@ def test_search_geojson(client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_search_geojson_extent(client):
+def test_search_geojson_extent(api_client):
     _load_sample_files()
-    results = json.loads(client.get('/api/geodata/geojson/extent').content)
+    results = json.loads(api_client.get('/api/geodata/geojson/extent').content)
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/geojson/extent',
             {
                 'geojson': json.dumps(
@@ -268,7 +268,7 @@ def test_search_geojson_extent(client):
     )
     assert results['count'] == 1
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/geojson/extent',
             {
                 'geojson': json.dumps(
@@ -286,14 +286,14 @@ def test_search_geojson_extent(client):
         '%Y-%m-%d %H:%M:%S'
     )
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/geojson/extent',
             {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content
     )
     assert results['count'] == len(SampleFiles)
     results = json.loads(
-        client.get(
+        api_client.get(
             '/api/geodata/raster/geojson/extent',
             {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
         ).content


### PR DESCRIPTION
Patch for https://github.com/girder/django-composed-configuration/pull/109

This changes the two tests hitting the POST endpoint to use an authenticated API client.

@brianhelba: for endpoints that are read-only, should we be using [`api_client` here](https://github.com/ResonantGeoData/ResonantGeoData/blob/87ba08fd261c34940d615c1f0e13874dc333e487/rgd/geodata/tests/conftest.py#L12) over the default `client` fixture (presumably coming from `pytest-django`... or where is that actually coming from?)?