### PR TITLE
Improve examination of HTTP response data in testing

### DIFF
--- a/rgd/core/urls.py
+++ b/rgd/core/urls.py
@@ -50,7 +50,6 @@ urlpatterns = [
     path('jobs/<str:creator>/<int:pk>/', views.JobDetailView.as_view(), name='job-detail'),
     path('tasks/', views.tasks, name='tasks'),
     path('task/<int:pk>-<str:name>/', views.TaskDetailView.as_view(), name='task-detail'),
-    path('api/core/download/<model>/<int:id>/<field>', views.download_file, name='download-file'),
     path('', include(router.urls)),
 ] + generate_routes({'flower-proxy': {'base_url': 'http://flower:5555/', 'prefix': '/flower/'}})
 

--- a/rgd/core/views.py
+++ b/rgd/core/views.py
@@ -1,19 +1,12 @@
 import logging
-import os
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.db.models.fields.files import FieldFile
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
-from django.utils.encoding import smart_str
 from django.views.decorators.http import require_http_methods
 from django.views.generic import CreateView, DeleteView, DetailView
-from drf_yasg.utils import swagger_auto_schema
-from rest_framework.decorators import api_view
 
-from . import models
 from .models import Algorithm, AlgorithmJob, ScoreJob, Task
 
 logger = logging.getLogger(__name__)
@@ -120,32 +113,3 @@ class JobCreateView(LoginRequiredMixin, CreateView):
         form.instance.creator = self.request.user
         form.instance.created = timezone.now()
         return super().form_valid(form)
-
-
-@swagger_auto_schema(
-    method='GET',
-    operation_summary='Download a model file',
-    operation_description='Download a model file through the server instead of from the assetstore',
-)
-@api_view(['GET'])
-def download_file(request, model, id, field):
-    model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])
-    if not hasattr(models, model_class):
-        raise Exception('No such model (%s)' % model)
-    model_inst = get_object_or_404(getattr(models, model_class), pk=id)
-    if not isinstance(getattr(model_inst, field, None), FieldFile):
-        raise Exception('No such file (%s)' % field)
-    file = getattr(model_inst, field)
-    filename = os.path.basename(file.name)
-    if not filename:
-        filename = '%s_%s_%s.dat' % (model, id, field)
-    mimetype = getattr(
-        model_inst,
-        '%s_mimetype' % field,
-        'text/plain' if field == 'log' else 'application/octet-stream',
-    )
-    response = HttpResponse(file.chunks(), content_type=mimetype)
-    response['Content-Disposition'] = smart_str(u'attachment; filename=%s' % filename)
-    if len(file) is not None:
-        response['Content-Length'] = len(file)
-    return response

--- a/rgd/geodata/api/download.py
+++ b/rgd/geodata/api/download.py
@@ -1,43 +1,10 @@
-import os
-
-from django.db.models.fields.files import FieldFile
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404  # , render
-from django.utils.encoding import smart_str
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from rgd.geodata import models
-
-
-@swagger_auto_schema(
-    method='GET',
-    operation_summary='Download a model file',
-    operation_description='Download a model file through the server instead of from the assetstore',
-)
-@api_view(['GET'])
-def download_file(request, model, id, field):
-    model_class = ''.join([part[:1].upper() + part[1:] for part in model.split('_')])
-    if not hasattr(models, model_class):
-        raise AttributeError('No such model (%s)' % model)
-    model_inst = get_object_or_404(getattr(models, model_class), pk=id)
-    if not isinstance(getattr(model_inst, field, None), FieldFile):
-        raise AttributeError('No such file (%s)' % field)
-    file = getattr(model_inst, field)
-    filename = os.path.basename(file.name)
-    if not filename:
-        filename = '%s_%s_%s.dat' % (model, id, field)
-    mimetype = getattr(
-        model_inst,
-        '%s_mimetype' % field,
-        'text/plain' if field == 'log' else 'application/octet-stream',
-    )
-    response = HttpResponse(file.chunks(), content_type=mimetype)
-    response['Content-Disposition'] = smart_str(u'attachment; filename=%s' % filename)
-    if len(file) is not None:
-        response['Content-Length'] = len(file)
-    return response
 
 
 @swagger_auto_schema(

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -57,7 +57,8 @@ def test_download_file(api_client, arbitrary_file):
     id = arbitrary_file.id
     field = 'file'
     response = api_client.get(f'/api/geodata/download/{model}/{id}/{field}')
-    assert response.status_code == 200, response.content
+    assert response.status_code == 200
+    assert response.data
     with pytest.raises(AttributeError):
         # Test bad model
         api_client.get('/api/geodata/download/Foo/0/file')
@@ -71,7 +72,8 @@ def test_get_status(api_client, astro_image):
     model = 'ImageFile'
     id = astro_image.image_file.imagefile.id
     response = api_client.get(f'/api/geodata/status/{model}/{id}')
-    assert response.status_code == 200, response.content
+    assert response.status_code == 200
+    assert response.data
     with pytest.raises(AttributeError):
         api_client.get(f'/api/geodata/status/Foo/{id}')
 
@@ -80,20 +82,22 @@ def test_get_status(api_client, astro_image):
 def test_download_arbitry_file(api_client, arbitrary_file):
     pk = arbitrary_file.pk
     response = api_client.get(f'/api/geodata/common/arbitrary_file/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200, response.content
+    assert response.status_code == 302 or response.status_code == 200
+    assert response.data
 
 
 @pytest.mark.django_db(transaction=True)
 def test_download_image_entry_file(api_client, astro_image):
     pk = astro_image.pk
     response = api_client.get(f'/api/geodata/imagery/image_entry/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200, response.content
+    assert response.status_code == 302 or response.status_code == 200
+    assert response.data
 
 
 @pytest.mark.django_db(transaction=True)
 def test_get_arbitrary_file(api_client, arbitrary_file):
     pk = arbitrary_file.pk
-    content = json.loads(api_client.get(f'/api/geodata/common/arbitrary_file/{pk}').content)
+    content = api_client.get(f'/api/geodata/common/arbitrary_file/{pk}').data
     assert content
     # Check that a hyperlink is given to the file data
     # NOTE: tried using the URLValidator from django but it thinks this URL is invalid
@@ -105,11 +109,10 @@ def test_get_spatial_entry(api_client, landsat_raster):
     """Test individual GET for SpatialEntry model."""
     pk = landsat_raster.rastermetaentry.spatial_id
     response = api_client.get(f'/api/geodata/common/spatial_entry/{pk}')
-    assert response.status_code == 200, response.content
-    content = json.loads(response.content)
-    assert content
-    assert content['footprint']
-    assert content['outline']
+    assert response.status_code == 200
+    assert response.data
+    assert response.data['footprint']
+    assert response.data['outline']
 
 
 @pytest.mark.django_db(transaction=True)
@@ -121,19 +124,20 @@ def test_create_get_subsampled_image(authenticated_api_client, astro_image):
         'sample_parameters': json.dumps({'umax': 100, 'umin': 0, 'vmax': 200, 'vmin': 0}),
     }
     response = authenticated_api_client.post('/api/geodata/imagery/subsample', payload)
-    assert response.status_code == 201, response.content
-    content = json.loads(response.content)
-    pk = content['pk']
+    assert response.status_code == 201
+    assert response.data
+    pk = response.data['pk']
     sub = models.imagery.SubsampledImage.objects.get(pk=pk)
     assert sub.data
     # Test the GET
     response = authenticated_api_client.get(f'/api/geodata/imagery/subsample/{pk}')
-    assert response.status_code == 200, response.content
+    assert response.status_code == 200
+    assert response.data
     # Now test to make sure the serializer prevents duplicates
     response = authenticated_api_client.post('/api/geodata/imagery/subsample', payload)
-    assert response.status_code == 201, response.content
-    content = json.loads(response.content)
-    assert pk == content['pk']  # Compare against original PK
+    assert response.status_code == 201
+    assert response.data
+    assert pk == response.data['pk']  # Compare against original PK
 
 
 @pytest.mark.django_db(transaction=True)
@@ -143,7 +147,8 @@ def test_create_and_download_cog(authenticated_api_client, landsat_image):
         '/api/geodata/imagery/cog',
         {'source_image': landsat_image.id},
     )
-    assert response.status_code == 201, response.content
+    assert response.status_code == 201
+    assert response.data
     # Check that a COG was generated
     cog = models.imagery.ConvertedImageFile.objects.get(source_image=landsat_image.id)
     # NOTE: This doesn't actually verify the file is in COG format. Assumed.
@@ -151,4 +156,5 @@ def test_create_and_download_cog(authenticated_api_client, landsat_image):
     # Also test download endpoint here:
     pk = cog.pk
     response = authenticated_api_client.get(f'/api/geodata/imagery/cog/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200, response.content
+    assert response.status_code == 302 or response.status_code == 200
+    assert response.data

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -52,22 +52,6 @@ def landsat_raster():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_download_file(api_client, arbitrary_file):
-    model = 'ArbitraryFile'
-    id = arbitrary_file.id
-    field = 'file'
-    response = api_client.get(f'/api/geodata/download/{model}/{id}/{field}')
-    assert response.status_code == 200
-    assert response.data
-    with pytest.raises(AttributeError):
-        # Test bad model
-        api_client.get('/api/geodata/download/Foo/0/file')
-    with pytest.raises(AttributeError):
-        # Test good model, bad field
-        api_client.get(f'/api/geodata/download/{model}/{id}/foo')
-
-
-@pytest.mark.django_db(transaction=True)
 def test_get_status(api_client, astro_image):
     model = 'ImageFile'
     id = astro_image.image_file.imagefile.id

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from rest_framework import status
 
 from rgd.geodata import models
 from rgd.geodata.datastore import datastore
@@ -66,16 +67,14 @@ def test_get_status(api_client, astro_image):
 def test_download_arbitry_file(api_client, arbitrary_file):
     pk = arbitrary_file.pk
     response = api_client.get(f'/api/geodata/common/arbitrary_file/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200
-    assert response.data
+    assert status.is_redirect(response.status_code)
 
 
 @pytest.mark.django_db(transaction=True)
 def test_download_image_entry_file(api_client, astro_image):
     pk = astro_image.pk
     response = api_client.get(f'/api/geodata/imagery/image_entry/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200
-    assert response.data
+    assert status.is_redirect(response.status_code)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -140,5 +139,4 @@ def test_create_and_download_cog(authenticated_api_client, landsat_image):
     # Also test download endpoint here:
     pk = cog.pk
     response = authenticated_api_client.get(f'/api/geodata/imagery/cog/{pk}/data')
-    assert response.status_code == 302 or response.status_code == 200
-    assert response.data
+    assert status.is_redirect(response.status_code)

--- a/rgd/geodata/tests/test_search.py
+++ b/rgd/geodata/tests/test_search.py
@@ -36,266 +36,220 @@ def _load_sample_files():
 @pytest.mark.django_db(transaction=True)
 def test_search_near_point(api_client):
     _load_sample_files()
-    items = json.loads(api_client.get('/api/geodata/near_point').content)
+    items = api_client.get('/api/geodata/near_point').data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get('/api/geodata/near_point', {'longitude': -79, 'latitude': 43}).content
-    )
+    items = api_client.get('/api/geodata/near_point', {'longitude': -79, 'latitude': 43}).data
     assert len(items) == 1
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/near_point', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/near_point', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
+    ).data
     assert len(items) == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/near_point',
-            {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/near_point',
+        {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
+    ).data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/near_point',
-            {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/near_point',
+        {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
+    ).data
     assert len(items) == 0
 
 
 @pytest.mark.django_db(transaction=True)
 def test_search_near_point_extent(api_client):
     _load_sample_files()
-    results = json.loads(api_client.get('/api/geodata/near_point/extent').content)
+    results = api_client.get('/api/geodata/near_point/extent').data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get('/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43}).content
-    )
+    results = api_client.get(
+        '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43}
+    ).data
     assert results['count'] == 1
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
+    ).data
     assert results['count'] == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/near_point/extent',
-            {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/near_point/extent',
+        {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
+    ).data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/near_point/extent',
-            {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/near_point/extent',
+        {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
+    ).data
     assert results['count'] == 0
 
 
 @pytest.mark.django_db(transaction=True)
 def test_search_bounding_box(api_client):
     _load_sample_files()
-    items = json.loads(api_client.get('/api/geodata/bounding_box').content)
+    items = api_client.get('/api/geodata/bounding_box').data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/bounding_box',
-            {
-                'minimum_longitude': -80,
-                'maximum_longitude': -79,
-                'minimum_latitude': 43,
-                'maximum_latitude': 44,
-            },
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/bounding_box',
+        {
+            'minimum_longitude': -80,
+            'maximum_longitude': -79,
+            'minimum_latitude': 43,
+            'maximum_latitude': 44,
+        },
+    ).data
     assert len(items) == 1
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/bounding_box',
-            {
-                'minimum_longitude': -90,
-                'maximum_longitude': -70,
-                'minimum_latitude': 30,
-                'maximum_latitude': 50,
-            },
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/bounding_box',
+        {
+            'minimum_longitude': -90,
+            'maximum_longitude': -70,
+            'minimum_latitude': 30,
+            'maximum_latitude': 50,
+        },
+    ).data
     assert len(items) == 3
     timestr = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
     oldtimestr = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime(
         '%Y-%m-%d %H:%M:%S'
     )
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/bounding_box',
-            {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/bounding_box',
+        {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/bounding_box',
-            {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/bounding_box',
+        {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert len(items) == 0
 
 
 @pytest.mark.django_db(transaction=True)
 def test_search_bounding_box_extent(api_client):
     _load_sample_files()
-    results = json.loads(api_client.get('/api/geodata/bounding_box/extent').content)
+    results = api_client.get('/api/geodata/bounding_box/extent').data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/bounding_box/extent',
-            {
-                'minimum_longitude': -80,
-                'maximum_longitude': -79,
-                'minimum_latitude': 43,
-                'maximum_latitude': 44,
-            },
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/bounding_box/extent',
+        {
+            'minimum_longitude': -80,
+            'maximum_longitude': -79,
+            'minimum_latitude': 43,
+            'maximum_latitude': 44,
+        },
+    ).data
     assert results['count'] == 1
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/bounding_box/extent',
-            {
-                'minimum_longitude': -90,
-                'maximum_longitude': -70,
-                'minimum_latitude': 30,
-                'maximum_latitude': 50,
-            },
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/bounding_box/extent',
+        {
+            'minimum_longitude': -90,
+            'maximum_longitude': -70,
+            'minimum_latitude': 30,
+            'maximum_latitude': 50,
+        },
+    ).data
     assert results['count'] == 3
     timestr = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
     oldtimestr = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime(
         '%Y-%m-%d %H:%M:%S'
     )
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/bounding_box/extent',
-            {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/bounding_box/extent',
+        {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/bounding_box/extent',
-            {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/bounding_box/extent',
+        {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert results['count'] == 0
 
 
 @pytest.mark.django_db(transaction=True)
 def test_search_geojson(api_client):
     _load_sample_files()
-    items = json.loads(api_client.get('/api/geodata/geojson').content)
+    items = api_client.get('/api/geodata/geojson').data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/geojson',
-            {
-                'geojson': json.dumps(
-                    {
-                        'type': 'Polygon',
-                        'coordinates': [[[-80, 43], [-80, 44], [-79, 44], [-79, 43], [-80, 43]]],
-                    }
-                )
-            },
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/geojson',
+        {
+            'geojson': json.dumps(
+                {
+                    'type': 'Polygon',
+                    'coordinates': [[[-80, 43], [-80, 44], [-79, 44], [-79, 43], [-80, 43]]],
+                }
+            )
+        },
+    ).data
     assert len(items) == 1
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/geojson',
-            {
-                'geojson': json.dumps(
-                    {
-                        'type': 'Polygon',
-                        'coordinates': [[[-90, 30], [-90, 50], [-70, 50], [-70, 30], [-90, 30]]],
-                    }
-                )
-            },
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/geojson',
+        {
+            'geojson': json.dumps(
+                {
+                    'type': 'Polygon',
+                    'coordinates': [[[-90, 30], [-90, 50], [-70, 50], [-70, 30], [-90, 30]]],
+                }
+            )
+        },
+    ).data
     assert len(items) == 3
     timestr = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
     oldtimestr = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime(
         '%Y-%m-%d %H:%M:%S'
     )
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/geojson',
-            {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/geojson',
+        {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert len(items) == len(SampleFiles)
-    items = json.loads(
-        api_client.get(
-            '/api/geodata/raster/geojson',
-            {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    items = api_client.get(
+        '/api/geodata/raster/geojson',
+        {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert len(items) == 0
 
 
 @pytest.mark.django_db(transaction=True)
 def test_search_geojson_extent(api_client):
     _load_sample_files()
-    results = json.loads(api_client.get('/api/geodata/geojson/extent').content)
+    results = api_client.get('/api/geodata/geojson/extent').data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/geojson/extent',
-            {
-                'geojson': json.dumps(
-                    {
-                        'type': 'Polygon',
-                        'coordinates': [[[-80, 43], [-80, 44], [-79, 44], [-79, 43], [-80, 43]]],
-                    }
-                )
-            },
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/geojson/extent',
+        {
+            'geojson': json.dumps(
+                {
+                    'type': 'Polygon',
+                    'coordinates': [[[-80, 43], [-80, 44], [-79, 44], [-79, 43], [-80, 43]]],
+                }
+            )
+        },
+    ).data
     assert results['count'] == 1
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/geojson/extent',
-            {
-                'geojson': json.dumps(
-                    {
-                        'type': 'Polygon',
-                        'coordinates': [[[-90, 30], [-90, 50], [-70, 50], [-70, 30], [-90, 30]]],
-                    }
-                )
-            },
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/geojson/extent',
+        {
+            'geojson': json.dumps(
+                {
+                    'type': 'Polygon',
+                    'coordinates': [[[-90, 30], [-90, 50], [-70, 50], [-70, 30], [-90, 30]]],
+                }
+            )
+        },
+    ).data
     assert results['count'] == 3
     timestr = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
     oldtimestr = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime(
         '%Y-%m-%d %H:%M:%S'
     )
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/geojson/extent',
-            {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/geojson/extent',
+        {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert results['count'] == len(SampleFiles)
-    results = json.loads(
-        api_client.get(
-            '/api/geodata/raster/geojson/extent',
-            {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
-        ).content
-    )
+    results = api_client.get(
+        '/api/geodata/raster/geojson/extent',
+        {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
+    ).data
     assert results['count'] == 0

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -35,11 +35,6 @@ urlpatterns = [
     ),
     #############
     path(
-        'api/geodata/download/<model>/<int:id>/<field>',
-        api.download.download_file,
-        name='download-file',
-    ),
-    path(
         'api/geodata/status/<model>/<int:pk>',
         api.download.get_status,
         name='get-status',


### PR DESCRIPTION
This improves 2 things:
* Use `response.data` instead of `json.loads(response.content)`. This still ensures that the DRF Serializers are invoked to serialize Model representations into primitive Python data structures, but avoids the code and performance overhead of encoding / decoding a JSON string. See: https://www.django-rest-framework.org/api-guide/testing/#checking-the-response-data (see #252)
* Perform each assert on its own line, which is syntactically necessary. Additional expressions to an `assert` statement are not interprepted as additional assertions to be made, but rather as the arguments (such as a failure message) to the `AssertionError` that a failure raises. See: https://docs.python.org/3/reference/simple_stmts.html#grammar-token-assert-stmt