### PR TITLE
Ensure local templates are still loaded first

### DIFF
--- a/rgd/settings.py
+++ b/rgd/settings.py
@@ -57,12 +57,12 @@ class RgdMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
 
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
-        # The allauth app also defines a base.html file, so core must be loaded
-        # before allauth.
+        # The girder_style app also defines a base.html file, so core must be loaded
+        # before girder_style.
         # Accordingly, RgdConfig must be loaded after AllauthConfig, so it can
         # find the existing entry and insert accordingly.
         try:
-            insert_index = configuration.INSTALLED_APPS.index('allauth')
+            insert_index = configuration.INSTALLED_APPS.index('girder_style')
         except ValueError:
             raise Exception('RgdConfig must be loaded after AllauthConfig.')
         # We also want our apps to be before any apps that we want to override

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'django-admin-display',
         'django-allauth',
         'django-cleanup',
-        'django-composed-configuration[dev,prod]>=0.10.0',
+        'django-composed-configuration[dev,prod]>=0.12.0',
         'django-configurations[database,email]',
         'django-crispy-forms',
         'django-extensions',


### PR DESCRIPTION
This adds support for the latest release of `django-composed-configuration`.