### PR TITLE
Use cookies to improve UI across page reloads

### DIFF
--- a/rgd/geodata/templates/geodata/_base/base.html
+++ b/rgd/geodata/templates/geodata/_base/base.html
@@ -8,6 +8,31 @@
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 
+    <script>
+      function setCookie(cookieName, cookieValue, nDays=365) {
+        var today = new Date();
+        var expire = new Date();
+        if (nDays==null || nDays==0) nDays=1;
+        expire.setTime(today.getTime() + 3600000*24*nDays);
+        document.cookie = cookieName+"="+escape(cookieValue)
+            + ";expires="+expire.toGMTString();
+      }
+
+      function getCookie(cookieName, defaultValue="") {
+        var theCookie=""+document.cookie;
+        var ind=theCookie.indexOf(cookieName+"=");
+        if (ind==-1 || cookieName=="") {
+          if (defaultValue != "") {
+            setCookie(cookieName, defaultValue);
+          }
+          return defaultValue;
+        }
+        var ind1=theCookie.indexOf(";",ind);
+        if (ind1==-1) { ind1=theCookie.length; }
+        return unescape(theCookie.substring(ind+cookieName.length+1,ind1));
+      }
+    </script>
+
     <link rel="stylesheet" href="{% static 'geodata/css/style.css' %}" />
 
     {% if title %}

--- a/rgd/geodata/templates/geodata/_base/base.html
+++ b/rgd/geodata/templates/geodata/_base/base.html
@@ -15,7 +15,7 @@
         if (nDays==null || nDays==0) nDays=1;
         expire.setTime(today.getTime() + 3600000*24*nDays);
         document.cookie = cookieName+"="+escape(cookieValue)
-            + ";expires="+expire.toGMTString();
+            + ";expires="+expire.toGMTString() + "; path=/";
       }
 
       function getCookie(cookieName, defaultValue="") {

--- a/rgd/geodata/templates/geodata/_includes/empty_viewer.html
+++ b/rgd/geodata/templates/geodata/_includes/empty_viewer.html
@@ -35,7 +35,7 @@
       clampBoundsX: true
     })
     basemapLayer = map.createLayer('osm', {
-      source: 'osm',
+      source: getCookie('basemapChoice', 'osm'),
       gcs: 'EPSG:3857' // web mercator
     });
 
@@ -58,10 +58,11 @@
     var basemapTool = ui.createWidget('dom', {position: {right: 20, top: 20}});
     basemapTool.canvas().appendChild(document.getElementById("basemapTool"))
 
+    var basemapDropdown = document.getElementById("basemapDropdown")
+    basemapDropdown.value = basemapLayer.source()
     function changeBasemap() {
-      var dropdown = document.getElementById("basemapDropdown")
-      console.log(dropdown.value)
-      basemapLayer.source(dropdown.value)
+      setCookie('basemapChoice', basemapDropdown.value)
+      basemapLayer.source(basemapDropdown.value)
     }
 
     // Annotation layer

--- a/rgd/geodata/templates/geodata/_includes/search_form.html
+++ b/rgd/geodata/templates/geodata/_includes/search_form.html
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div class="column is-full">
-        <div id="stPoint" class="selection" style="display: block;">
+        <div id="stPoint" class="selection" style="display: none;">
           <form method="GET">
             <div class="columns is-multiline mx-0">
               <div class="column is-full field mb-0">

--- a/rgd/geodata/templates/geodata/_includes/search_form.html
+++ b/rgd/geodata/templates/geodata/_includes/search_form.html
@@ -297,11 +297,15 @@
       });
     }
 
+    var selectionType = document.getElementById("selectionType")
     $(function() {
       $('#selectionType').change(function(){
         $('.selection').hide();
         $('#' + $(this).val()).show();
+        setCookie('searchType', $(this)[0].value)
       });
+      selectionType.value = getCookie('searchType', 'stPoint')
+      $('#selectionType').change()
     });
 
   </script>


### PR DESCRIPTION
The base map and search fields would reset anytime the page reloads (necessary because we are using server-rendered pages). These changes add cookies to the site to set the search field and preferred base map so that they stay consistent across pages

| `master` | this branch |
|---|---|
| ![2021-02-01 20 24 22](https://user-images.githubusercontent.com/22067021/106548135-b4d61600-64cb-11eb-81e5-698c2266d578.gif) |  ![2021-02-01 20 24 01](https://user-images.githubusercontent.com/22067021/106548141-ba336080-64cb-11eb-819d-c00397291803.gif) |

Since these cookies have to do with UI elements and not the Django view, I went with a classic cookies approach rather than Django's tooling to set cookies.

It's a bit crude but it works until we make the switch to a single page app with Vue

Todo

- [x] Make site-wide