### PR TITLE
PATCH: fix JSONField double encoding in test

### DIFF
--- a/rgd/geodata/models/imagery/base.py
+++ b/rgd/geodata/models/imagery/base.py
@@ -3,6 +3,7 @@ from django.contrib.gis.db import models
 from django.contrib.postgres import fields
 from django.utils.html import escape, mark_safe
 from django.utils.translation import gettext_lazy as _
+import json
 
 from rgd.utility import _link_url
 
@@ -243,6 +244,8 @@ class SubsampledImage(ModifiableEntry, TaskEventMixin):
 
         """
         p = self.sample_parameters
+        if isinstance(p, str):
+            p = json.loads(p)
         if self.sample_type == SubsampledImage.SampleTypes.PIXEL_BOX:
             # -srcwin <xoff> <yoff> <xsize> <ysize>
             return dict(srcWin=[p['umin'], p['vmin'], p['umax'] - p['umin'], p['vmax'] - p['vmin']])

--- a/rgd/geodata/models/imagery/base.py
+++ b/rgd/geodata/models/imagery/base.py
@@ -1,6 +1,4 @@
 """Base classes for raster dataset entries."""
-import json
-
 from django.contrib.gis.db import models
 from django.contrib.postgres import fields
 from django.utils.html import escape, mark_safe
@@ -245,8 +243,6 @@ class SubsampledImage(ModifiableEntry, TaskEventMixin):
 
         """
         p = self.sample_parameters
-        if isinstance(p, str):
-            p = json.loads(p)
         if self.sample_type == SubsampledImage.SampleTypes.PIXEL_BOX:
             # -srcwin <xoff> <yoff> <xsize> <ysize>
             return dict(srcWin=[p['umin'], p['vmin'], p['umax'] - p['umin'], p['vmax'] - p['vmin']])

--- a/rgd/geodata/models/imagery/base.py
+++ b/rgd/geodata/models/imagery/base.py
@@ -1,9 +1,10 @@
 """Base classes for raster dataset entries."""
+import json
+
 from django.contrib.gis.db import models
 from django.contrib.postgres import fields
 from django.utils.html import escape, mark_safe
 from django.utils.translation import gettext_lazy as _
-import json
 
 from rgd.utility import _link_url
 

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from rest_framework import status
 
@@ -120,7 +118,7 @@ def test_create_get_subsampled_image(authenticated_api_client, astro_image):
     payload = {
         'source_image': astro_image.pk,
         'sample_type': 'pixel box',
-        'sample_parameters': json.dumps({'umax': 100, 'umin': 0, 'vmax': 200, 'vmin': 0}),
+        'sample_parameters': {'umax': 100, 'umin': 0, 'vmax': 200, 'vmin': 0},
     }
     response = authenticated_api_client.post('/api/geodata/imagery/subsample', payload)
     assert response.status_code == 201


### PR DESCRIPTION
Fixes an issue causing tests to fail across PRs. The post request was double encoding a `JSONField`