### PR TITLE
Add basic back button to detail view

### DIFF
--- a/rgd/geodata/templates/geodata/_base/detail.html
+++ b/rgd/geodata/templates/geodata/_base/detail.html
@@ -1,5 +1,6 @@
 {% extends "geodata/_base/base.html" %}
 {% block title %}
+  <input class="button is-secondary" type="button" value="&#x2190; Back to Search" onclick="history.back()">
   {{ object.name | truncatechars:36 }} ({{object.pk}})
 {% endblock title %}
 


### PR DESCRIPTION
Simple back button to the detail page UI

<img width="206" alt="Screen Shot 2021-02-22 at 10 04 12 PM" src="https://user-images.githubusercontent.com/22067021/108804220-e9cd0a00-7559-11eb-842a-6ded2e9b04aa.png">



This is a simple solution before we make the switch to a single page app