### PR TITLE
Expose flower via docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,6 +46,8 @@ services:
   flower:
     image: mher/flower
     command: ["--broker=amqp://rabbitmq:5672/", "--url_prefix=flower"]
+    ports:
+      - 5555:5555
 
   sass:
     build:


### PR DESCRIPTION
Now flower is exposed for monitoring tasks at: http://localhost:5555/flower/dashboard