### PR TITLE
[CI] Move linting to its own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,14 @@ jobs:
           name: Run linting
           command: tox -e lint
       - run:
+          name: Run check migrations
+          command: tox -e check-migrations
+          environment:
+            DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
+            DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
+            DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
+            DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
+      - run:
           name: Run tests
           command: tox -e test
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,11 @@ jobs:
           name: Install tox and codecov
           command: sudo pip install tox codecov
       - run:
+          name: Run linting
+          command: tox -e lint
+      - run:
           name: Run tests
-          command: tox
+          command: tox -e test
           environment:
             DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
             DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000


### PR DESCRIPTION
This moves the tests and linting into their own steps on CircleCI so it's easier to see what's going on/why a build failed

| `master` | this branch |
|---|---|
| <img width="1192" alt="Screen Shot 2021-03-05 at 12 08 08 PM" src="https://user-images.githubusercontent.com/22067021/110162068-76be6180-7dab-11eb-88eb-ebb02c3a071f.png"> | <img width="1201" alt="Screen Shot 2021-03-05 at 12 07 31 PM" src="https://user-images.githubusercontent.com/22067021/110162019-60180a80-7dab-11eb-984e-6068470e62ee.png"> |
