### PR TITLE
Move patch_internal_presign

### DIFF
--- a/rgd/geodata/api/tiles.py
+++ b/rgd/geodata/api/tiles.py
@@ -13,7 +13,7 @@ class BaseTileView(APIView):
         """Return the built tile source."""
         image_entry = get_object_or_404(ImageEntry, pk=pk)
         self.check_object_permissions(request, image_entry)
-        file_path = image_entry.image_file.file.get_vsi_path()
+        file_path = image_entry.image_file.file.get_vsi_path(internal=True)
         projection = request.query_params.get('projection', 'EPSG:3857')
         tile_source = GDALFileTileSource(file_path, projection=projection, encoding='PNG')
         return tile_source

--- a/rgd/geodata/api/tiles.py
+++ b/rgd/geodata/api/tiles.py
@@ -13,7 +13,7 @@ class BaseTileView(APIView):
         """Return the built tile source."""
         image_entry = get_object_or_404(ImageEntry, pk=pk)
         self.check_object_permissions(request, image_entry)
-        file_path = image_entry.image_file.file.get_local_vsi_path()
+        file_path = image_entry.image_file.file.get_vsi_path()
         projection = request.query_params.get('projection', 'EPSG:3857')
         tile_source = GDALFileTileSource(file_path, projection=projection, encoding='PNG')
         return tile_source

--- a/rgd/geodata/models/common.py
+++ b/rgd/geodata/models/common.py
@@ -206,7 +206,7 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
         ----------
         vsi : bool
             If FUSE fails, fallback to a Virtual File Systems URL. See
-            ``get_local_vsi_path``. This is especially useful if the file
+            ``get_vsi_path``. This is especially useful if the file
             is being utilized by GDAL and FUSE is not set up.
 
         """
@@ -214,7 +214,7 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
             return url_file_to_fuse_path(self.get_url())
         elif vsi:
             logger.info('`yield_local_path` falling back to Virtual File System URL.')
-            return self.yield_local_vsi_path()
+            return self.yield_vsi_path()
         # Fallback to loading entire file locally
         logger.info('`yield_local_path` falling back to downloading entire file to local storage.')
         if self.type == FileSourceType.FILE_FIELD:
@@ -242,7 +242,7 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
 
     data_link.allow_tags = True
 
-    def get_local_vsi_path(self) -> str:
+    def get_vsi_path(self) -> str:
         """Return the GDAL Virtual File Systems [0] URL.
 
         This currently formulates the `/vsicurl/...` URL [1] for internal and
@@ -283,6 +283,6 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
         return vsicurl
 
     @contextmanager
-    def yield_local_vsi_path(self):
-        """Wrap ``get_local_vsi_path`` in a context manager."""
-        yield self.get_local_vsi_path()
+    def yield_vsi_path(self):
+        """Wrap ``get_vsi_path`` in a context manager."""
+        yield self.get_vsi_path()


### PR DESCRIPTION
@mcovalt, is it okay to move `patch_internal_presign` into `get_url` directly? Sometimes we need the minio URL if doing FUSE and not VFS

Also I renamed `get_local_vsi_path()` to `get_vsi_path()` as this should work in any environment