### PR TITLE
Fix skip_signal typo

### DIFF
--- a/rgd/geodata/management/commands/_data_helper.py
+++ b/rgd/geodata/management/commands/_data_helper.py
@@ -37,13 +37,13 @@ def _get_or_download_checksum_file(name):
     return file_entry
 
 
-def _get_or_create_file_model(model, name, skip_task=False):
+def _get_or_create_file_model(model, name, skip_signal=False):
     # For models that point to a `ChecksumFile`
     file_entry = _get_or_download_checksum_file(name)
     entry, _ = model.objects.get_or_create(file=file_entry)
     # In case the last population failed
-    if skip_task:
-        entry.skip_task = True
+    if skip_signal:
+        entry.skip_signal = True
     if entry.status != models.mixins.Status.SUCCEEDED:
         entry.save()
     return entry
@@ -56,7 +56,7 @@ def load_image_files(image_files):
             result = load_image_files(imfile)
         else:
             # Run `read_image_file` sequentially to ensure `ImageEntry` is generated
-            entry = _get_or_create_file_model(models.ImageFile, imfile, skip_task=True)
+            entry = _get_or_create_file_model(models.ImageFile, imfile, skip_signal=True)
             read_image_file(entry)
             result = entry.imageentry.pk
         ids.append(result)

--- a/rgd/geodata/models/imagery/etl.py
+++ b/rgd/geodata/models/imagery/etl.py
@@ -489,7 +489,7 @@ def load_kwcoco_dataset(kwcoco_dataset_id):
             name = os.path.basename(image_file_abs_path)
             image_file = ImageFile()
             image_file.collection = ds_entry.spec_file.collection
-            image_file.skip_task = True
+            image_file.skip_signal = True
             image_file.file = ChecksumFile()
             image_file.file.file.save(name, open(image_file_abs_path, 'rb'))
             image_file.save()


### PR DESCRIPTION
Quick patch for #297 

This resolves the issue, but I want to keep #297 open until we have a better way to handle the `skip_signal` functionality to prevent typos like this from happening again