### PR TITLE
Add contextmanager around urlopen and use to get remote file names

### DIFF
--- a/rgd/geodata/management/commands/_data_helper.py
+++ b/rgd/geodata/management/commands/_data_helper.py
@@ -1,20 +1,20 @@
 from functools import reduce
 import os
-from urllib.request import urlopen
 
 from django.db.models import Count
 
 from rgd.geodata import models, tasks
 from rgd.geodata.datastore import datastore, registry
 from rgd.geodata.models.imagery.etl import read_image_file
-from rgd.utility import get_or_create_no_commit
+from rgd.utility import get_or_create_no_commit, safe_urlopen
 
 
 def _get_or_download_checksum_file(name):
     # Check if there is already an image file with this sha or URL
     #  to avoid duplicating data
     try:
-        _ = urlopen(name)  # HACK: see if URL first
+        with safe_urlopen(name) as _:
+            pass  # HACK: see if URL first
         try:
             file_entry = models.ChecksumFile.objects.get(url=name)
         except models.ChecksumFile.DoesNotExist:

--- a/rgd/geodata/models/common.py
+++ b/rgd/geodata/models/common.py
@@ -1,7 +1,7 @@
-from contextlib import contextmanager
+import contextlib
 import logging
 import os
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 # from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
@@ -17,6 +17,7 @@ from rgd.utility import (
     compute_checksum_url,
     patch_internal_presign,
     precheck_fuse,
+    safe_urlopen,
     url_file_to_fuse_path,
     url_file_to_local_path,
 )
@@ -210,8 +211,8 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
             if self.type == FileSourceType.FILE_FIELD and self.file.name:
                 self.name = os.path.basename(self.file.name)
             elif self.type == FileSourceType.URL:
-                # TODO: this isn't the best approach
-                self.name = os.path.basename(urlparse(self.url).path)
+                with safe_urlopen(self.url) as r:
+                    self.name = r.info().get_filename()
         # Must save the model with the file before accessing it for the checksum
         super(ChecksumFile, self).save(*args, **kwargs)
 
@@ -310,7 +311,7 @@ class ChecksumFile(ModifiableEntry, TaskEventMixin):
         logger.info(f'vsicurl URL: {vsicurl}')
         return vsicurl
 
-    @contextmanager
+    @contextlib.contextmanager
     def yield_vsi_path(self, internal=False):
         """Wrap ``get_vsi_path`` in a context manager."""
         yield self.get_vsi_path(internal=internal)


### PR DESCRIPTION
Previously when adding a remote file (via just an URL) the `name` field on the model would be improperly populated when dealing with a direct download link becaue it naively used `os.path.basename` on the URL.

These changes use features of `urlopen` to inspect the file at the link and fetch its name.

For the file at this url, `https://data.kitware.com/api/v1/file/604a547c2fa25629b93176d2/download` we see the following names:

| `master` | this branch |
|---|---|
|`download` | `20151007_063901_dstoMX20HD__EON_High_012_298-520_600-280.mpg`|

This PR also wraps `urlopen` in a context manager to make sure we close it when we're done looking at a file