### PR TITLE
Resolve duplicated tasks in demo commands

### DIFF
--- a/rgd/geodata/management/commands/_data_helper.py
+++ b/rgd/geodata/management/commands/_data_helper.py
@@ -40,11 +40,12 @@ def _get_or_download_checksum_file(name):
 def _get_or_create_file_model(model, name, skip_signal=False):
     # For models that point to a `ChecksumFile`
     file_entry = _get_or_download_checksum_file(name)
-    entry, _ = model.objects.get_or_create(file=file_entry)
+    # No commit in case we need to skip the signal
+    entry, created = get_or_create_no_commit(model, file=file_entry)
     # In case the last population failed
     if skip_signal:
         entry.skip_signal = True
-    if entry.status != models.mixins.Status.SUCCEEDED:
+    if created or entry.status != models.mixins.Status.SUCCEEDED:
         entry.save()
     return entry
 


### PR DESCRIPTION
This resolves #297

The issue was that `get_or_create` was committing the entry to the DB triggering a `save` call triggering the tasks and then we were running the ETL routine again after that causing the duplicate key error