### PR TITLE
Fix index URL redirect

### DIFF
--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.views.generic.base import RedirectView
 
 from . import api, views
 

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -6,15 +6,13 @@ from . import api, views
 urlpatterns = [
     # Pages
     path(
-        'geodata/spatial_entries/', views.SpatialEntriesListView.as_view(), name='spatial_entries'
+        r'', views.SpatialEntriesListView.as_view(), name='index'
     ),
     path(
         'geodata/spatial_entries/<int:pk>/',
         views.spatial_entry_redirect_view,
         name='spatial-entry-detail',
     ),
-    # Temporary redirect for home page
-    path(r'', RedirectView.as_view(url='geodata/spatial_entries/', permanent=False), name='index'),
     path(
         'geodata/rasters/<int:pk>/',
         views.RasterEntryDetailView.as_view(),

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -5,9 +5,7 @@ from . import api, views
 
 urlpatterns = [
     # Pages
-    path(
-        r'', views.SpatialEntriesListView.as_view(), name='index'
-    ),
+    path(r'', views.SpatialEntriesListView.as_view(), name='index'),
     path(
         'geodata/spatial_entries/<int:pk>/',
         views.spatial_entry_redirect_view,


### PR DESCRIPTION
We had the base URL redirecting to `geodata/spatial_entries/`. This removes that and puts the spatial entries list view/search page as the homepage.