### PR TITLE
Add condition to prevent loading empty tiles for rasters on frontend

### DIFF
--- a/rgd/geodata/templates/geodata/rastermetaentry_detail.html
+++ b/rgd/geodata/templates/geodata/rastermetaentry_detail.html
@@ -69,6 +69,17 @@
     var tiles = map.createLayer('osm', {keepLower: false, attribution: ''});
     tiles.opacity(0.75)
 
+    // Make sure regions outside the extent of the raster do not load null tiles
+    //   this relieves strain on the tile server
+    const dataset_bb = extents.extent;
+    tiles.isValid = (index) => {
+      const tileBounds = tiles.gcsTileBounds(index);
+      return tileBounds.left <= dataset_bb.xmax &&
+        tileBounds.right >= dataset_bb.xmin &&
+        tileBounds.top >= dataset_bb.ymin &&
+        tileBounds.bottom <= dataset_bb.ymax;
+    }
+
     function updateBandThumbnail () {
       selector = document.getElementById('band-selector')
       thumbnail = document.getElementById('thumbnail')


### PR DESCRIPTION
This helps relieve some of the stress #323 is experiencing.

These changes make sure the front-end tile layer in GeoJS is not fetching empty/null tiles outside the extent of the raster. Previously, we were loading tiles for the entire map view -- they'd just be transparent if the raster had no data there. You could notice this by watching the tile requests continue in the logs after the ROI is seemingly done loading or you could change the image compression to JPEG to make null regions opaque.

For any given raster, now only the tiles intersecting the raster are fetched by GeoJS' tile layer

## `master`
https://user-images.githubusercontent.com/22067021/112364614-5728a380-8c9c-11eb-9663-70c1f06c99f7.mov 

## this branch
https://user-images.githubusercontent.com/22067021/112364515-382a1180-8c9c-11eb-9769-23fb9aafbb7a.mov