### PR TITLE
More robust dev server configuration for demoing

### DIFF
--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -1,4 +1,4 @@
-DJANGO_CONFIGURATION=DevelopmentConfiguration
+DJANGO_CONFIGURATION=NonDebugDevConfiguration
 DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
 DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/
 DJANGO_MINIO_STORAGE_ENDPOINT=minio:9000

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,8 @@ services:
     build:
       context: .
       dockerfile: ./dev/django.Dockerfile
-    command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    #command: ["./manage.py", "runserver", "0.0.0.0:8000"]
+    command: ["gunicorn", "-k", "gthread", "--threads", "8", "--bind", "0.0.0.0:8000", "rgd.wsgi"]
     # Log printing via Rich is enhanced by a TTY
     tty: true
     env_file: ./dev/.env.docker-compose

--- a/rgd/settings.py
+++ b/rgd/settings.py
@@ -96,6 +96,10 @@ class DevelopmentConfiguration(RgdMixin, DevelopmentBaseConfiguration):
     pass
 
 
+class NonDebugDevConfiguration(DevelopmentConfiguration):
+    DEBUG = True
+
+
 class TestingConfiguration(RgdMixin, TestingBaseConfiguration):
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'django-composed-configuration[prod]',
         'django-s3-file-field[minio]',
         'flower',
-        'gunicorn',
+        'gunicorn[gthread]',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This uses gunicorn with 8 concurrent threads to make for a better demo from someone's local setup. This makes tile serving somewhat faster, and also partly mitigates the page refusing to reload issue. It also disables debug mode on the server side, which could have performance benefits, but I have not actually measured those. Prior to this change, the server could only handle a single request at a time in dev mode. Using the threaded mode of gunicorn should also prevent subverting our caching behavior.