### PR TITLE
API Improvements

### DIFF
--- a/demos/GeoData-API.ipynb
+++ b/demos/GeoData-API.ipynb
@@ -14,7 +14,8 @@
     "from rasterio.plot import show\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import json"
+    "import json\n",
+    "from requests.auth import HTTPBasicAuth"
    ]
   },
   {
@@ -25,8 +26,8 @@
    "source": [
     "class GeoData:\n",
     "    HOST = 'http://localhost:8000'\n",
-    "    def __init__(self,):\n",
-    "        pass\n",
+    "    def __init__(self, user, password):\n",
+    "        self.auth=HTTPBasicAuth(user, password)\n",
     "\n",
     "    @staticmethod\n",
     "    def _load_image(content):\n",
@@ -38,23 +39,81 @@
     "        dataset = memfile.open()\n",
     "        return dataset\n",
     "\n",
-    "    @staticmethod\n",
-    "    def get_subsampled_raster(pk):\n",
-    "        a = requests.get(f'{GeoData.HOST}/api/geodata/imagery/subsample/{pk}')\n",
-    "        b = requests.get(a.json()['data'])\n",
+    "    def get_subsampled_raster(self, pk):\n",
+    "        a = requests.get(f'{GeoData.HOST}/api/geoprocess/imagery/subsample/{pk}', auth=self.auth)\n",
+    "        b = requests.get(a.json()['data']['file'], auth=self.auth)\n",
     "        #return GeoData._load_image(b.content)\n",
     "        return GeoData._load_raster(b.content)\n",
     "\n",
-    "    @staticmethod\n",
-    "    def get_image_entry(pk):\n",
-    "        a = requests.get(f'{GeoData.HOST}/api/geodata/imagery/image_entry/{pk}/data')\n",
+    "    def get_image_entry(self, pk):\n",
+    "        a = requests.get(f'{GeoData.HOST}/api/geodata/imagery/image_entry/{pk}/data', auth=self.auth)\n",
     "        #return GeoData._load_image(a.content)\n",
     "        return GeoData._load_raster(a.content)\n",
     "    \n",
-    "    @staticmethod\n",
-    "    def post_subsample(payload):\n",
-    "        a = requests.post(f'{GeoData.HOST}/api/geodata/imagery/subsample', json=payload)\n",
-    "        return json.loads(a.content)\n"
+    "    def post_subsample(self, payload):\n",
+    "        a = requests.post(f'{GeoData.HOST}/api/geoprocess/imagery/subsample', json=payload, auth=self.auth)\n",
+    "        return json.loads(a.content)\n",
+    "    \n",
+    "    def search(self, payload):\n",
+    "        a = requests.get(f'{GeoData.HOST}/api/geosearch', params=payload, auth=self.auth)\n",
+    "        return json.loads(a.content)\n",
+    "    \n",
+    "    def get(self, url):\n",
+    "        a = requests.get(url, auth=self.auth)\n",
+    "        return json.loads(a.content)\n",
+    "        \n",
+    "client = GeoData('user', 'password')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bbox = {\"type\":\"Polygon\",\n",
+    " \"coordinates\":[[[-107.24629793033489,38.821513321590224],\n",
+    "                 [-107.24629793033489,39.21393900330613],\n",
+    "                 [-106.49448944065813,39.21393900330613],\n",
+    "                 [-106.49448944065813,38.821513321590224],\n",
+    "                 [-107.24629793033489,38.821513321590224]]]\n",
+    "}\n",
+    "\n",
+    "search_params = {\n",
+    "    \"q\": json.dumps(bbox),\n",
+    "    \"predicate\": \"within\",\n",
+    "    \"datatype\": \"raster\",\n",
+    "}\n",
+    "\n",
+    "r = client.search(search_params)\n",
+    "r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sp = r['results'][0]\n",
+    "sp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raster = client.get(sp['detail'])\n",
+    "raster"
    ]
   },
   {
@@ -70,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img_id = 174"
+    "img_id = raster['image_set']['images'][0]['id']"
    ]
   },
   {
@@ -79,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = GeoData.get_image_entry(img_id)\n",
+    "src = client.get_image_entry(img_id)\n",
     "show(src)"
    ]
   },
@@ -123,7 +182,7 @@
     "            'sample_parameters': shape,\n",
     "        }\n",
     "\n",
-    "result = GeoData.post_subsample(payload)\n",
+    "result = client.post_subsample(payload)\n",
     "result"
    ]
   },
@@ -133,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "product = GeoData.get_subsampled_raster(result['pk'])"
+    "product = client.get_subsampled_raster(result['id'])"
    ]
   },
   {
@@ -162,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img_id = 145"
+    "img_id = 234"
    ]
   },
   {
@@ -171,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = GeoData.get_image_entry(img_id)\n",
+    "src = client.get_image_entry(img_id)\n",
     "# show(src)"
    ]
   },
@@ -184,10 +243,10 @@
     "payload = {\n",
     "            'source_image': img_id,\n",
     "            'sample_type': 'annotation',\n",
-    "            'sample_parameters': {'id': 161, 'outline': True},\n",
+    "            'sample_parameters': {'id': 251, 'outline': True},\n",
     "        }\n",
     "\n",
-    "result = GeoData.post_subsample(payload)\n",
+    "result = client.post_subsample(payload)\n",
     "result"
    ]
   },
@@ -197,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "product = GeoData.get_subsampled_raster(result['pk'])"
+    "product = client.get_subsampled_raster(result['id'])"
    ]
   },
   {

--- a/demos/GeoData-API.ipynb
+++ b/demos/GeoData-API.ipynb
@@ -46,7 +46,7 @@
     "        return GeoData._load_raster(b.content)\n",
     "\n",
     "    def get_image_entry(self, pk):\n",
-    "        a = requests.get(f'{GeoData.HOST}/api/geodata/imagery/image_entry/{pk}/data', auth=self.auth)\n",
+    "        a = requests.get(f'{GeoData.HOST}/api/geodata/imagery/{pk}/data', auth=self.auth)\n",
     "        #return GeoData._load_image(a.content)\n",
     "        return GeoData._load_raster(a.content)\n",
     "    \n",

--- a/rgd/geodata/api/get.py
+++ b/rgd/geodata/api/get.py
@@ -50,10 +50,10 @@ class GetImageSet(RetrieveAPIView, _PermissionMixin):
     queryset = models.ImageSet.objects.all()
 
 
-class GetRasterEntry(RetrieveAPIView, _PermissionMixin):
-    serializer_class = serializers.RasterEntrySerializer
+class GetRasterMetaEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.RasterMetaEntrySerializer
     lookup_field = 'pk'
-    queryset = models.RasterEntry.objects.all()
+    queryset = models.RasterMetaEntry.objects.all()
 
 
 class GetGeometryEntry(RetrieveAPIView, _PermissionMixin):
@@ -70,5 +70,11 @@ class GetGeometryEntryData(RetrieveAPIView, _PermissionMixin):
 
 class GetFMVEntry(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.FMVEntrySerializer
+    lookup_field = 'pk'
+    queryset = models.FMVEntry.objects.all()
+
+
+class GetFMVDataEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.FMVEntryDataSerializer
     lookup_field = 'pk'
     queryset = models.FMVEntry.objects.all()

--- a/rgd/geodata/api/get.py
+++ b/rgd/geodata/api/get.py
@@ -66,3 +66,9 @@ class GetGeometryEntryData(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.GeometryEntryDataSerializer
     lookup_field = 'pk'
     queryset = models.GeometryEntry.objects.all()
+
+
+class GetFMVEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.FMVEntrySerializer
+    lookup_field = 'pk'
+    queryset = models.FMVEntry.objects.all()

--- a/rgd/geodata/api/get.py
+++ b/rgd/geodata/api/get.py
@@ -2,9 +2,7 @@ from rest_framework.generics import RetrieveAPIView
 
 from rgd.geodata.permissions import check_read_perm
 
-from .. import serializers
-from ..models.common import ChecksumFile, SpatialEntry
-from ..models.imagery import ConvertedImageFile, SubsampledImage
+from .. import models, serializers
 
 
 class _PermissionMixin:
@@ -19,22 +17,52 @@ class GetConvertedImageStatus(RetrieveAPIView, _PermissionMixin):
 
     serializer_class = serializers.ConvertedImageFileSerializer
     lookup_field = 'pk'
-    queryset = ConvertedImageFile.objects.all()
+    queryset = models.ConvertedImageFile.objects.all()
 
 
 class GetSubsampledImage(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.SubsampledImageSerializer
     lookup_field = 'pk'
-    queryset = SubsampledImage.objects.all()
+    queryset = models.SubsampledImage.objects.all()
 
 
 class GetChecksumFile(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.ChecksumFileSerializer
     lookup_field = 'pk'
-    queryset = ChecksumFile.objects.all()
+    queryset = models.ChecksumFile.objects.all()
 
 
 class GetSpatialEntry(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.SpatialEntrySerializer
     lookup_field = 'spatial_id'
-    queryset = SpatialEntry.objects.all()
+    queryset = models.SpatialEntry.objects.all()
+
+
+class GetImageEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.ImageEntrySerializer
+    lookup_field = 'pk'
+    queryset = models.ImageEntry.objects.all()
+
+
+class GetImageSet(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.ImageSetSerializer
+    lookup_field = 'pk'
+    queryset = models.ImageSet.objects.all()
+
+
+class GetRasterEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.RasterEntrySerializer
+    lookup_field = 'pk'
+    queryset = models.RasterEntry.objects.all()
+
+
+class GetGeometryEntry(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.GeometryEntrySerializer
+    lookup_field = 'pk'
+    queryset = models.GeometryEntry.objects.all()
+
+
+class GetGeometryEntryData(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.GeometryEntryDataSerializer
+    lookup_field = 'pk'
+    queryset = models.GeometryEntry.objects.all()

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -21,7 +21,7 @@ class SpatialEntrySerializer(serializers.ModelSerializer):
             ret['subentry_pk'] = value.subentry.pk
             ret['subentry_name'] = value.subentry_name
             if subtype == 'RasterMetaEntry':
-                subtype_uri = reverse('raster-entry', args=[value.subentry.pk])
+                subtype_uri = reverse('raster-entry', args=[value.subentry.parent_raster.pk])
             elif subtype == 'GeometryEntry':
                 subtype_uri = reverse('geometry-entry', args=[value.subentry.pk])
             elif subtype == 'FMVEntry':

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -28,6 +28,11 @@ class GeometryEntrySerializer(SpatialEntrySerializer):
 
 
 class GeometryEntryDataSerializer(SpatialEntrySerializer):
+    def to_representation(self, value):
+        ret = super().to_representation(value)
+        ret['data'] = json.loads(value.data.geojson)
+        return ret
+
     class Meta:
         model = models.GeometryEntry
         fields = '__all__'

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -14,6 +14,23 @@ class SpatialEntrySerializer(serializers.ModelSerializer):
         ret = super().to_representation(value)
         ret['footprint'] = json.loads(value.footprint.geojson)
         ret['outline'] = json.loads(value.outline.geojson)
+        # Add hyperlink to get view for subtype if SpatialEntry
+        if type(value).__name__ != value.subentry_type:
+            subtype = value.subentry_type
+            ret['subentry_type'] = subtype
+            ret['subentry_pk'] = value.subentry.pk
+            ret['subentry_name'] = value.subentry_name
+            if subtype == 'RasterMetaEntry':
+                subtype_uri = reverse('raster-entry', args=[value.subentry.pk])
+            elif subtype == 'GeometryEntry':
+                subtype_uri = reverse('geometry-entry', args=[value.subentry.pk])
+            elif subtype == 'FMVEntry':
+                subtype_uri = reverse('fmv-entry', args=[value.subentry.pk])
+            if 'request' in self.context:
+                request = self.context['request']
+                ret['detail'] = request.build_absolute_uri(subtype_uri)
+            else:
+                ret['detail'] = subtype_uri
         return ret
 
     class Meta:

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -113,7 +113,7 @@ class SubsampledImageSerializer(serializers.ModelSerializer):
         return obj
 
 
-class _ImageFileSerializer(serializers.ModelSerializer):
+class ImageFileSerializer(serializers.ModelSerializer):
     file = ChecksumFileSerializer()
 
     class Meta:
@@ -122,7 +122,7 @@ class _ImageFileSerializer(serializers.ModelSerializer):
 
 
 class ImageEntrySerializer(serializers.ModelSerializer):
-    image_file = _ImageFileSerializer()
+    image_file = ImageFileSerializer()
 
     class Meta:
         model = models.ImageEntry
@@ -151,7 +151,7 @@ class ImageSetSerializer(serializers.ModelSerializer):
         ]
 
 
-class _RasterEntrySerializer(serializers.ModelSerializer):
+class RasterEntrySerializer(serializers.ModelSerializer):
     image_set = ImageSetSerializer()
     ancillary_files = ChecksumFileSerializer(many=True)
 
@@ -161,14 +161,14 @@ class _RasterEntrySerializer(serializers.ModelSerializer):
 
 
 class RasterMetaEntrySerializer(SpatialEntrySerializer):
-    parent_raster = _RasterEntrySerializer()
+    parent_raster = RasterEntrySerializer()
 
     class Meta:
         model = models.RasterMetaEntry
         fields = '__all__'
 
 
-class _FMVFileSerializer(serializers.ModelSerializer):
+class FMVFileSerializer(serializers.ModelSerializer):
     file = ChecksumFileSerializer()
 
     class Meta:
@@ -177,7 +177,7 @@ class _FMVFileSerializer(serializers.ModelSerializer):
 
 
 class FMVEntrySerializer(SpatialEntrySerializer):
-    fmv_file = _FMVFileSerializer()
+    fmv_file = FMVFileSerializer()
 
     class Meta:
         model = models.FMVEntry

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -144,4 +144,10 @@ class RasterEntrySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class FMVEntrySerializer(SpatialEntrySerializer):
+    class Meta:
+        model = models.FMVEntry
+        fields = '__all__'
+
+
 utility.make_serializers(globals(), models)

--- a/rgd/geodata/templates/geodata/rastermetaentry_detail.html
+++ b/rgd/geodata/templates/geodata/rastermetaentry_detail.html
@@ -87,8 +87,8 @@
       console.log(image_id)
       if (image_id >= 0) {
         tiles.visible(true)
-        tiles.url(`${host}/api/geodata/imagery/image_entry/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
-        thumbnail.src = `${host}/api/geodata/imagery/image_entry/${image_id}/thumbnail`
+        tiles.url(`${host}/api/geoprocess/imagery/image_entry/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
+        thumbnail.src = `${host}/api/geoprocess/imagery/image_entry/${image_id}/thumbnail`
         thumbnail.hidden = false
       } else {
         tiles.visible(false)

--- a/rgd/geodata/templates/geodata/rastermetaentry_detail.html
+++ b/rgd/geodata/templates/geodata/rastermetaentry_detail.html
@@ -87,8 +87,8 @@
       console.log(image_id)
       if (image_id >= 0) {
         tiles.visible(true)
-        tiles.url(`${host}/api/geoprocess/imagery/image_entry/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
-        thumbnail.src = `${host}/api/geoprocess/imagery/image_entry/${image_id}/thumbnail`
+        tiles.url(`${host}/api/geoprocess/imagery/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
+        thumbnail.src = `${host}/api/geoprocess/imagery/${image_id}/thumbnail`
         thumbnail.hidden = false
       } else {
         tiles.visible(false)

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -87,7 +87,7 @@ def test_download_checksum_file_url(admin_api_client, checksum_file_url):
 @pytest.mark.django_db(transaction=True)
 def test_download_image_entry_file(admin_api_client, astro_image):
     pk = astro_image.pk
-    response = admin_api_client.get(f'/api/geodata/imagery/image_entry/{pk}/data')
+    response = admin_api_client.get(f'/api/geodata/imagery/{pk}/data')
     assert status.is_redirect(response.status_code)
 
 

--- a/rgd/geodata/tests/test_api.py
+++ b/rgd/geodata/tests/test_api.py
@@ -120,28 +120,28 @@ def test_create_get_subsampled_image(admin_api_client, astro_image):
         'sample_type': 'pixel box',
         'sample_parameters': {'umax': 100, 'umin': 0, 'vmax': 200, 'vmin': 0},
     }
-    response = admin_api_client.post('/api/geodata/imagery/subsample', payload)
+    response = admin_api_client.post('/api/geoprocess/imagery/subsample', payload)
     assert response.status_code == 201
     assert response.data
-    pk = response.data['pk']
-    sub = models.imagery.SubsampledImage.objects.get(pk=pk)
+    id = response.data['id']
+    sub = models.imagery.SubsampledImage.objects.get(id=id)
     assert sub.data
     # Test the GET
-    response = admin_api_client.get(f'/api/geodata/imagery/subsample/{pk}')
+    response = admin_api_client.get(f'/api/geoprocess/imagery/subsample/{id}')
     assert response.status_code == 200
     assert response.data
     # Now test to make sure the serializer prevents duplicates
-    response = admin_api_client.post('/api/geodata/imagery/subsample', payload)
+    response = admin_api_client.post('/api/geoprocess/imagery/subsample', payload)
     assert response.status_code == 201
     assert response.data
-    assert pk == response.data['pk']  # Compare against original PK
+    assert id == response.data['id']  # Compare against original PK
 
 
 @pytest.mark.django_db(transaction=True)
 def test_create_and_download_cog(admin_api_client, landsat_image):
     """Test POST for ConvertedImageFile model."""
     response = admin_api_client.post(
-        '/api/geodata/imagery/cog',
+        '/api/geoprocess/imagery/cog',
         {'source_image': landsat_image.id},
     )
     assert response.status_code == 201
@@ -152,5 +152,5 @@ def test_create_and_download_cog(admin_api_client, landsat_image):
     assert cog.converted_file
     # Also test download endpoint here:
     pk = cog.pk
-    response = admin_api_client.get(f'/api/geodata/imagery/cog/{pk}/data')
+    response = admin_api_client.get(f'/api/geoprocess/imagery/cog/{pk}/data')
     assert status.is_redirect(response.status_code)

--- a/rgd/geodata/tests/test_search.py
+++ b/rgd/geodata/tests/test_search.py
@@ -36,22 +36,24 @@ def _load_sample_files():
 @pytest.mark.django_db(transaction=True)
 def test_search_near_point(admin_api_client):
     _load_sample_files()
-    items = admin_api_client.get('/api/geodata/near_point').data
+    items = admin_api_client.get('/api/geosearch/near_point').data
     assert len(items) == len(SampleFiles)
-    items = admin_api_client.get('/api/geodata/near_point', {'longitude': -79, 'latitude': 43}).data
+    items = admin_api_client.get(
+        '/api/geosearch/near_point', {'longitude': -79, 'latitude': 43}
+    ).data
     assert len(items) == 1
     items = admin_api_client.get(
-        '/api/geodata/near_point', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
+        '/api/geosearch/near_point', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
     ).data
     assert len(items) == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     items = admin_api_client.get(
-        '/api/geodata/raster/near_point',
+        '/api/geosearch/raster/near_point',
         {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
     ).data
     assert len(items) == len(SampleFiles)
     items = admin_api_client.get(
-        '/api/geodata/raster/near_point',
+        '/api/geosearch/raster/near_point',
         {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
     ).data
     assert len(items) == 0
@@ -60,24 +62,24 @@ def test_search_near_point(admin_api_client):
 @pytest.mark.django_db(transaction=True)
 def test_search_near_point_extent(admin_api_client):
     _load_sample_files()
-    results = admin_api_client.get('/api/geodata/near_point/extent').data
+    results = admin_api_client.get('/api/geosearch/near_point/extent').data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43}
+        '/api/geosearch/near_point/extent', {'longitude': -79, 'latitude': 43}
     ).data
     assert results['count'] == 1
     results = admin_api_client.get(
-        '/api/geodata/near_point/extent', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
+        '/api/geosearch/near_point/extent', {'longitude': -79, 'latitude': 43, 'radius': 1000000}
     ).data
     assert results['count'] == 3
     timestr = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     results = admin_api_client.get(
-        '/api/geodata/raster/near_point/extent',
+        '/api/geosearch/raster/near_point/extent',
         {'time': timestr, 'timefield': 'acquisition', 'timespan': 86400},
     ).data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/raster/near_point/extent',
+        '/api/geosearch/raster/near_point/extent',
         {'time': timestr, 'timefield': 'acquisition', 'timespan': 0},
     ).data
     assert results['count'] == 0
@@ -86,10 +88,10 @@ def test_search_near_point_extent(admin_api_client):
 @pytest.mark.django_db(transaction=True)
 def test_search_bounding_box(admin_api_client):
     _load_sample_files()
-    items = admin_api_client.get('/api/geodata/bounding_box').data
+    items = admin_api_client.get('/api/geosearch/bounding_box').data
     assert len(items) == len(SampleFiles)
     items = admin_api_client.get(
-        '/api/geodata/bounding_box',
+        '/api/geosearch/bounding_box',
         {
             'minimum_longitude': -80,
             'maximum_longitude': -79,
@@ -99,7 +101,7 @@ def test_search_bounding_box(admin_api_client):
     ).data
     assert len(items) == 1
     items = admin_api_client.get(
-        '/api/geodata/bounding_box',
+        '/api/geosearch/bounding_box',
         {
             'minimum_longitude': -90,
             'maximum_longitude': -70,
@@ -113,12 +115,12 @@ def test_search_bounding_box(admin_api_client):
         '%Y-%m-%d %H:%M:%S'
     )
     items = admin_api_client.get(
-        '/api/geodata/raster/bounding_box',
+        '/api/geosearch/raster/bounding_box',
         {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert len(items) == len(SampleFiles)
     items = admin_api_client.get(
-        '/api/geodata/raster/bounding_box',
+        '/api/geosearch/raster/bounding_box',
         {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert len(items) == 0
@@ -127,10 +129,10 @@ def test_search_bounding_box(admin_api_client):
 @pytest.mark.django_db(transaction=True)
 def test_search_bounding_box_extent(admin_api_client):
     _load_sample_files()
-    results = admin_api_client.get('/api/geodata/bounding_box/extent').data
+    results = admin_api_client.get('/api/geosearch/bounding_box/extent').data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/bounding_box/extent',
+        '/api/geosearch/bounding_box/extent',
         {
             'minimum_longitude': -80,
             'maximum_longitude': -79,
@@ -140,7 +142,7 @@ def test_search_bounding_box_extent(admin_api_client):
     ).data
     assert results['count'] == 1
     results = admin_api_client.get(
-        '/api/geodata/bounding_box/extent',
+        '/api/geosearch/bounding_box/extent',
         {
             'minimum_longitude': -90,
             'maximum_longitude': -70,
@@ -154,12 +156,12 @@ def test_search_bounding_box_extent(admin_api_client):
         '%Y-%m-%d %H:%M:%S'
     )
     results = admin_api_client.get(
-        '/api/geodata/raster/bounding_box/extent',
+        '/api/geosearch/raster/bounding_box/extent',
         {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/raster/bounding_box/extent',
+        '/api/geosearch/raster/bounding_box/extent',
         {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert results['count'] == 0
@@ -168,10 +170,10 @@ def test_search_bounding_box_extent(admin_api_client):
 @pytest.mark.django_db(transaction=True)
 def test_search_geojson(admin_api_client):
     _load_sample_files()
-    items = admin_api_client.get('/api/geodata/geojson').data
+    items = admin_api_client.get('/api/geosearch/geojson').data
     assert len(items) == len(SampleFiles)
     items = admin_api_client.get(
-        '/api/geodata/geojson',
+        '/api/geosearch/geojson',
         {
             'geojson': json.dumps(
                 {
@@ -183,7 +185,7 @@ def test_search_geojson(admin_api_client):
     ).data
     assert len(items) == 1
     items = admin_api_client.get(
-        '/api/geodata/geojson',
+        '/api/geosearch/geojson',
         {
             'geojson': json.dumps(
                 {
@@ -199,12 +201,12 @@ def test_search_geojson(admin_api_client):
         '%Y-%m-%d %H:%M:%S'
     )
     items = admin_api_client.get(
-        '/api/geodata/raster/geojson',
+        '/api/geosearch/raster/geojson',
         {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert len(items) == len(SampleFiles)
     items = admin_api_client.get(
-        '/api/geodata/raster/geojson',
+        '/api/geosearch/raster/geojson',
         {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert len(items) == 0
@@ -213,10 +215,10 @@ def test_search_geojson(admin_api_client):
 @pytest.mark.django_db(transaction=True)
 def test_search_geojson_extent(admin_api_client):
     _load_sample_files()
-    results = admin_api_client.get('/api/geodata/geojson/extent').data
+    results = admin_api_client.get('/api/geosearch/geojson/extent').data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/geojson/extent',
+        '/api/geosearch/geojson/extent',
         {
             'geojson': json.dumps(
                 {
@@ -228,7 +230,7 @@ def test_search_geojson_extent(admin_api_client):
     ).data
     assert results['count'] == 1
     results = admin_api_client.get(
-        '/api/geodata/geojson/extent',
+        '/api/geosearch/geojson/extent',
         {
             'geojson': json.dumps(
                 {
@@ -244,12 +246,12 @@ def test_search_geojson_extent(admin_api_client):
         '%Y-%m-%d %H:%M:%S'
     )
     results = admin_api_client.get(
-        '/api/geodata/raster/geojson/extent',
+        '/api/geosearch/raster/geojson/extent',
         {'start_time': oldtimestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert results['count'] == len(SampleFiles)
     results = admin_api_client.get(
-        '/api/geodata/raster/geojson/extent',
+        '/api/geosearch/raster/geojson/extent',
         {'start_time': timestr, 'end_time': timestr, 'timefield': 'acquisition'},
     ).data
     assert results['count'] == 0

--- a/rgd/geodata/tests/test_tiles.py
+++ b/rgd/geodata/tests/test_tiles.py
@@ -16,7 +16,7 @@ def image_entry():
 
 @pytest.mark.django_db(transaction=True)
 def test_metadata(api_client, image_entry):
-    response = api_client.get(f'/api/geodata/imagery/image_entry/{image_entry.pk}/tiles')
+    response = api_client.get(f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/tiles')
     metadata = response.data
     assert metadata['levels'] == 15
     assert metadata['sizeX'] == metadata['sizeY']
@@ -26,13 +26,15 @@ def test_metadata(api_client, image_entry):
 
 @pytest.mark.django_db(transaction=True)
 def test_tile(api_client, image_entry):
-    response = api_client.get(f'/api/geodata/imagery/image_entry/{image_entry.pk}/tiles/1/0/0.png')
+    response = api_client.get(
+        f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/tiles/1/0/0.png'
+    )
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'
 
 
 @pytest.mark.django_db(transaction=True)
 def test_thumbnail(api_client, image_entry):
-    response = api_client.get(f'/api/geodata/imagery/image_entry/{image_entry.pk}/thumbnail')
+    response = api_client.get(f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/thumbnail')
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'

--- a/rgd/geodata/tests/test_tiles.py
+++ b/rgd/geodata/tests/test_tiles.py
@@ -16,7 +16,7 @@ def image_entry():
 
 @pytest.mark.django_db(transaction=True)
 def test_metadata(api_client, image_entry):
-    response = api_client.get(f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/tiles')
+    response = api_client.get(f'/api/geoprocess/imagery/{image_entry.pk}/tiles')
     metadata = response.data
     assert metadata['levels'] == 15
     assert metadata['sizeX'] == metadata['sizeY']
@@ -26,15 +26,13 @@ def test_metadata(api_client, image_entry):
 
 @pytest.mark.django_db(transaction=True)
 def test_tile(api_client, image_entry):
-    response = api_client.get(
-        f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/tiles/1/0/0.png'
-    )
+    response = api_client.get(f'/api/geoprocess/imagery/{image_entry.pk}/tiles/1/0/0.png')
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'
 
 
 @pytest.mark.django_db(transaction=True)
 def test_thumbnail(api_client, image_entry):
-    response = api_client.get(f'/api/geoprocess/imagery/image_entry/{image_entry.pk}/thumbnail')
+    response = api_client.get(f'/api/geoprocess/imagery/{image_entry.pk}/thumbnail')
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -81,12 +81,12 @@ urlpatterns = [
         name='geometry-entry-data',
     ),
     path(
-        'api/geodata/imagery/image_entry/<int:pk>',
+        'api/geodata/imagery/<int:pk>',
         api.get.GetImageEntry.as_view(),
         name='image-entry',
     ),
     path(
-        'api/geodata/imagery/image_entry/<int:pk>/data',
+        'api/geodata/imagery/<int:pk>/data',
         api.download.download_image_entry_file,
         name='image-entry-data',
     ),
@@ -113,17 +113,17 @@ urlpatterns = [
     #############
     # Geoprocessing
     path(
-        'api/geoprocess/imagery/image_entry/<int:pk>/tiles',
+        'api/geoprocess/imagery/<int:pk>/tiles',
         api.tiles.TileMetadataView.as_view(),
         name='image-tile-metadata',
     ),
     path(
-        'api/geoprocess/imagery/image_entry/<int:pk>/tiles/<int:z>/<int:x>/<int:y>.png',
+        'api/geoprocess/imagery/<int:pk>/tiles/<int:z>/<int:x>/<int:y>.png',
         api.tiles.TileView.as_view(),
         name='image-tiles',
     ),
     path(
-        'api/geoprocess/imagery/image_entry/<int:pk>/thumbnail',
+        'api/geoprocess/imagery/<int:pk>/thumbnail',
         api.tiles.TileThumnailView.as_view(),
         name='image-thumbnail',
     ),

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -96,7 +96,7 @@ urlpatterns = [
         name='image-set',
     ),
     path(
-        'api/geodata/imagery/raster_meta_entry/<int:pk>',
+        'api/geodata/imagery/raster/<int:pk>',
         api.get.GetRasterMetaEntry.as_view(),
         name='raster-meta-entry',
     ),

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -26,34 +26,40 @@ urlpatterns = [
         name='geometry-entry-detail',
     ),
     #############
+    # Search
+    path('api/geosearch/near_point', api.search.search_near_point),
+    path('api/geosearch/raster/near_point', api.search.search_near_point_raster),
+    path('api/geosearch/geometry/near_point', api.search.search_near_point_geometry),
+    path('api/geosearch/near_point/extent', api.search.search_near_point_extent),
+    path('api/geosearch/raster/near_point/extent', api.search.search_near_point_extent_raster),
+    path('api/geosearch/geometry/near_point/extent', api.search.search_near_point_extent_geometry),
+    path('api/geosearch/bounding_box', api.search.search_bounding_box),
+    path('api/geosearch/raster/bounding_box', api.search.search_bounding_box_raster),
+    path('api/geosearch/geometry/bounding_box', api.search.search_bounding_box_geometry),
+    path('api/geosearch/bounding_box/extent', api.search.search_bounding_box_extent),
+    path('api/geosearch/raster/bounding_box/extent', api.search.search_bounding_box_extent_raster),
+    path(
+        'api/geosearch/geometry/bounding_box/extent', api.search.search_bounding_box_extent_geometry
+    ),
+    path('api/geosearch/geojson', api.search.search_geojson),
+    path('api/geosearch/raster/geojson', api.search.search_geojson_raster),
+    path('api/geosearch/geometry/geojson', api.search.search_geojson_geometry),
+    path('api/geosearch/geojson/extent', api.search.search_geojson_extent),
+    path('api/geosearch/raster/geojson/extent', api.search.search_geojson_extent_raster),
+    path('api/geosearch/geometry/geojson/extent', api.search.search_geojson_extent_geometry),
+    path('api/geosearch', api.search.SearchSpatialEntryView.as_view()),
+    #############
+    # Other
     path(
         'api/geodata/status/<model>/<int:pk>',
         api.download.get_status,
         name='get-status',
     ),
-    # Search
-    path('api/geodata/near_point', api.search.search_near_point),
-    path('api/geodata/raster/near_point', api.search.search_near_point_raster),
-    path('api/geodata/geometry/near_point', api.search.search_near_point_geometry),
-    path('api/geodata/near_point/extent', api.search.search_near_point_extent),
-    path('api/geodata/raster/near_point/extent', api.search.search_near_point_extent_raster),
-    path('api/geodata/geometry/near_point/extent', api.search.search_near_point_extent_geometry),
-    path('api/geodata/bounding_box', api.search.search_bounding_box),
-    path('api/geodata/raster/bounding_box', api.search.search_bounding_box_raster),
-    path('api/geodata/geometry/bounding_box', api.search.search_bounding_box_geometry),
-    path('api/geodata/bounding_box/extent', api.search.search_bounding_box_extent),
-    path('api/geodata/raster/bounding_box/extent', api.search.search_bounding_box_extent_raster),
     path(
-        'api/geodata/geometry/bounding_box/extent', api.search.search_bounding_box_extent_geometry
+        'api/geodata/common/spatial_entry/<int:spatial_id>',
+        api.get.GetSpatialEntry.as_view(),
+        name='spatial-entry',
     ),
-    path('api/geodata/geojson', api.search.search_geojson),
-    path('api/geodata/raster/geojson', api.search.search_geojson_raster),
-    path('api/geodata/geometry/geojson', api.search.search_geojson_geometry),
-    path('api/geodata/geojson/extent', api.search.search_geojson_extent),
-    path('api/geodata/raster/geojson/extent', api.search.search_geojson_extent_raster),
-    path('api/geodata/geometry/geojson/extent', api.search.search_geojson_extent_geometry),
-    path('api/geodata/search', api.search.SearchSpatialEntryView.as_view()),
-    # Other
     path(
         'api/geodata/common/checksum_file/<int:pk>',
         api.get.GetChecksumFile.as_view(),
@@ -65,53 +71,75 @@ urlpatterns = [
         name='checksum-file-data',
     ),
     path(
+        'api/geodata/geometry/<int:pk>',
+        api.get.GetGeometryEntry.as_view(),
+        name='geometry-entry',
+    ),
+    path(
+        'api/geodata/geometry/<int:pk>/data',
+        api.get.GetGeometryEntryData.as_view(),
+        name='geometry-entry-data',
+    ),
+    path(
+        'api/geodata/imagery/image_entry/<int:pk>',
+        api.get.GetImageEntry.as_view(),
+        name='image-entry',
+    ),
+    path(
         'api/geodata/imagery/image_entry/<int:pk>/data',
         api.download.download_image_entry_file,
         name='image-entry-data',
     ),
     path(
-        'api/geodata/common/spatial_entry/<int:spatial_id>',
-        api.get.GetSpatialEntry.as_view(),
-        name='spatial-entry',
-    ),
-    path('api/geodata/imagery/cog', api.post.CreateConvertedImageFile.as_view()),
-    path(
-        'api/geodata/imagery/cog/<int:pk>',
-        api.get.GetConvertedImageStatus.as_view(),
-        name='cog',
-    ),
-    path(
-        'api/geodata/imagery/cog/<int:pk>/data',
-        api.download.download_cog_file,
-        name='cog-data',
-    ),
-    path(
-        'api/geodata/imagery/subsample',
-        api.post.CreateSubsampledImage.as_view(),
-    ),
-    path(
-        'api/geodata/imagery/subsample/<int:pk>',
-        api.get.GetSubsampledImage.as_view(),
-        name='subsampled',
-    ),
-    path(
-        'api/geodata/imagery/subsample/<int:pk>/status',
-        api.download.get_status_subsampled_image,
-        name='subsampled-status',
-    ),
-    path(
         'api/geodata/imagery/image_entry/<int:pk>/tiles',
         api.tiles.TileMetadataView.as_view(),
-        name='tilemetadata',
+        name='image-tile-metadata',
     ),
     path(
         'api/geodata/imagery/image_entry/<int:pk>/tiles/<int:z>/<int:x>/<int:y>.png',
         api.tiles.TileView.as_view(),
-        name='tile',
+        name='image-tiles',
     ),
     path(
         'api/geodata/imagery/image_entry/<int:pk>/thumbnail',
         api.tiles.TileThumnailView.as_view(),
-        name='thumbnail',
+        name='image-thumbnail',
+    ),
+    path(
+        'api/geodata/imagery/image_set/<int:pk>',
+        api.get.GetImageSet.as_view(),
+        name='image-set',
+    ),
+    path(
+        'api/geodata/imagery/raster_entry/<int:pk>',
+        api.get.GetRasterEntry.as_view(),
+        name='raster-entry',
+    ),
+    #############
+    # Geoprocessing
+    path('api/geoprocess/imagery/cog', api.post.CreateConvertedImageFile.as_view()),
+    path(
+        'api/geoprocess/imagery/cog/<int:pk>',
+        api.get.GetConvertedImageStatus.as_view(),
+        name='cog',
+    ),
+    path(
+        'api/geoprocess/imagery/cog/<int:pk>/data',
+        api.download.download_cog_file,
+        name='cog-data',
+    ),
+    path(
+        'api/geoprocess/imagery/subsample',
+        api.post.CreateSubsampledImage.as_view(),
+    ),
+    path(
+        'api/geoprocess/imagery/subsample/<int:pk>',
+        api.get.GetSubsampledImage.as_view(),
+        name='subsampled',
+    ),
+    path(
+        'api/geoprocess/imagery/subsample/<int:pk>/status',
+        api.download.get_status_subsampled_image,
+        name='subsampled-status',
     ),
 ]

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -115,6 +115,11 @@ urlpatterns = [
         api.get.GetRasterEntry.as_view(),
         name='raster-entry',
     ),
+    path(
+        'api/geodata/fmv/<int:pk>',
+        api.get.GetFMVEntry.as_view(),
+        name='fmv-entry',
+    ),
     #############
     # Geoprocessing
     path('api/geoprocess/imagery/cog', api.post.CreateConvertedImageFile.as_view()),

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -91,21 +91,6 @@ urlpatterns = [
         name='image-entry-data',
     ),
     path(
-        'api/geodata/imagery/image_entry/<int:pk>/tiles',
-        api.tiles.TileMetadataView.as_view(),
-        name='image-tile-metadata',
-    ),
-    path(
-        'api/geodata/imagery/image_entry/<int:pk>/tiles/<int:z>/<int:x>/<int:y>.png',
-        api.tiles.TileView.as_view(),
-        name='image-tiles',
-    ),
-    path(
-        'api/geodata/imagery/image_entry/<int:pk>/thumbnail',
-        api.tiles.TileThumnailView.as_view(),
-        name='image-thumbnail',
-    ),
-    path(
         'api/geodata/imagery/image_set/<int:pk>',
         api.get.GetImageSet.as_view(),
         name='image-set',
@@ -122,6 +107,21 @@ urlpatterns = [
     ),
     #############
     # Geoprocessing
+    path(
+        'api/geoprocess/imagery/image_entry/<int:pk>/tiles',
+        api.tiles.TileMetadataView.as_view(),
+        name='image-tile-metadata',
+    ),
+    path(
+        'api/geoprocess/imagery/image_entry/<int:pk>/tiles/<int:z>/<int:x>/<int:y>.png',
+        api.tiles.TileView.as_view(),
+        name='image-tiles',
+    ),
+    path(
+        'api/geoprocess/imagery/image_entry/<int:pk>/thumbnail',
+        api.tiles.TileThumnailView.as_view(),
+        name='image-thumbnail',
+    ),
     path('api/geoprocess/imagery/cog', api.post.CreateConvertedImageFile.as_view()),
     path(
         'api/geoprocess/imagery/cog/<int:pk>',

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -96,14 +96,19 @@ urlpatterns = [
         name='image-set',
     ),
     path(
-        'api/geodata/imagery/raster_entry/<int:pk>',
-        api.get.GetRasterEntry.as_view(),
-        name='raster-entry',
+        'api/geodata/imagery/raster_meta_entry/<int:pk>',
+        api.get.GetRasterMetaEntry.as_view(),
+        name='raster-meta-entry',
     ),
     path(
         'api/geodata/fmv/<int:pk>',
         api.get.GetFMVEntry.as_view(),
         name='fmv-entry',
+    ),
+    path(
+        'api/geodata/fmv/<int:pk>/data',
+        api.get.GetFMVDataEntry.as_view(),
+        name='fmv-entry-data',
     ),
     #############
     # Geoprocessing


### PR DESCRIPTION
For #332 

Adds new serializers/endpoints to make it easier to perform a search and go straight to downloading data

This splits up the `geodata` endpoints into three new tags:

- `geodata`: for accessing models via serializer and downloading raw data
- `geosearch`: for performing searches against data in the catalog
- `geoprocess`: for performing operations on data in the catalog (e.g. subsampling, COG conversion, tiling)

I updated the demo notebook (`demos/GeoData-API.ipynb`) to show what is now possible - this is a developer's demo and not intended to be shown externally. @AlmightyYakob, this should be everything needed to proceed with #332 