### PR TITLE
Bump Django to release version 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'django==3.2a1',  # See PR #264: due to this bug: https://code.djangoproject.com/ticket/31910
+        'django>=3.2',  # See PR #264: due to this bug: https://code.djangoproject.com/ticket/31910
         'django-admin-display',
         'django-allauth',
         'django-cleanup',


### PR DESCRIPTION
3.2 is out, so now we should use the public (presumably stable) version. See https://www.djangoproject.com/weblog/2021/apr/06/django-32-released/