### PR TITLE
Add url to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     license='Apache 2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
+    url='https://github.com/ResonantGeoData/ResonantGeoData',
     keywords='',
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Pypi doesn't have a link to the github webpage. This fixes that.