### PR TITLE
Add pagination to `Rgdc.search`

### DIFF
--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -217,7 +217,7 @@ class Rgdc:
             offset: The number of results to skip.
 
         Returns:
-            An list of Spatial Entries.
+            A list of Spatial Entries.
         """
         # The dict that will be used to store params.
         # Initialize with queries that won't be additionally processed.

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -11,7 +11,12 @@ from tqdm import tqdm
 
 from .session import RgdcSession
 from .types import DATETIME_OR_STR_TUPLE, SEARCH_DATATYPE_CHOICE, SEARCH_PREDICATE_CHOICE
-from .utils import DEFAULT_RGD_API, datetime_to_str, download_checksum_file_to_path
+from .utils import (
+    DEFAULT_RGD_API,
+    datetime_to_str,
+    download_checksum_file_to_path,
+    limit_offset_pager,
+)
 
 
 @dataclass
@@ -281,6 +286,4 @@ class Rgdc:
             params['frame_rate_min'] = frmin
             params['frame_rate_max'] = frmax
 
-        response = self.session.get('geosearch', params=params)
-        response.raise_for_status()
-        return [result for result in response.json()['results']]
+        yield from limit_offset_pager(self.session, 'geosearch', params=params)

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -190,7 +190,7 @@ class Rgdc:
         frame_rate: Optional[Tuple[int, int]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> Iterator[Dict]:
+    ) -> List[Dict]:
         """
         Search for geospatial entries based on various criteria.
 
@@ -286,4 +286,4 @@ class Rgdc:
             params['frame_rate_min'] = frmin
             params['frame_rate_max'] = frmax
 
-        yield from limit_offset_pager(self.session, 'geosearch', params=params)
+        return list(limit_offset_pager(self.session, 'geosearch', params=params))

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, Generator, Iterator, List, Optional
 
 import requests
 from requests import Response, Session
@@ -20,7 +20,7 @@ def pager(session: Session, url: str, **kwargs) -> Iterator[Response]:
             break
 
 
-def limit_offset_pager(session: Session, url: str, **kwargs) -> Iterator[Response]:
+def limit_offset_pager(session: Session, url: str, **kwargs) -> Generator[Dict, None, None]:
     """Exhaust a DRF Paginated list, respecting limit/offset."""
     # Default params kwarg
     if not kwargs.get('params'):


### PR DESCRIPTION
Closes #354, Supersedes #359.

This conflicts with #360, although I was unaware of this PR until now. However, I think my PR addresses slightly more use cases than that one.

Currently, this function will fetch as many results as it can from the server at once, and paginate until the user specified limit is reached. So, for example, if the user specifies a limit of 1200, this function will first just pass that limit to the server, which will only return 1000 results, since that's the silent max. This function will then fetch the remaining 200 results after that.

However, I've also considered modifying this function to always use the server default of 100, and deal with the limit solely in the client. The main reason for this would be to keep individual request times down, as for 1000 results, the requests can take around 20 seconds. This would mean a slightly higher overall time for fetching the same amount of data, but would also allow for a more flexible use of the data. Thoughts @banesullivan @matt-bernstein?

*Closes #360*