### PR TITLE
Rgdc usability improvements

### DIFF
--- a/rgdc/README.md
+++ b/rgdc/README.md
@@ -62,7 +62,7 @@ load_image = lambda imbytes: imageio.imread(BytesIO(imbytes))
 
 count = len(raster['parent_raster']['image_set']['images'])
 for i in range(count):
-    thumb_bytes = client.download_raster_entry_thumbnail(raster['id'], band=i)
+    thumb_bytes = client.download_raster_entry_thumbnail(q[0], band=i)
     thumb = load_image(thumb_bytes)
     plt.subplot(1, count, i+1)
     plt.imshow(thumb)
@@ -76,8 +76,8 @@ plt.show()
 import rasterio
 from rasterio.plot import show
 
-paths = client.download_raster_entry(raster['id'])
-rasters = [rasterio.open(im) for im in paths['images']]
+paths = client.download_raster_entry(q[0])
+rasters = [rasterio.open(im) for im in paths.images]
 for i, src in enumerate(rasters):
     plt.subplot(1, count, i+1)
     ax = plt.gca()

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -55,8 +55,6 @@ class Rgdc:
     def list_image_entry_tiles(self, image_entry_id: Union[str, int]) -> Dict:
         """List geodata imagery image_entry tiles."""
         r = self.session.get(f'geodata/imagery/{image_entry_id}/tiles')
-        r.raise_for_status()
-
         return r.json()
 
     def download_image_entry_file(
@@ -73,8 +71,6 @@ class Rgdc:
             An iterator of byte chunks.
         """
         r = self.session.get(f'geodata/imagery/{image_entry_id}/data', stream=True)
-        r.raise_for_status()
-
         return r.iter_content(chunk_size=chunk_size)
 
     def download_image_entry_thumbnail(
@@ -91,7 +87,6 @@ class Rgdc:
             Thumbnail bytes.
         """
         r = self.session.get(f'geoprocess/imagery/{image_entry_id}/thumbnail')
-        r.raise_for_status()
         return r.content
 
     def download_raster_entry_thumbnail(
@@ -113,7 +108,6 @@ class Rgdc:
             raster_meta_entry_id = spatial_subentry_id(raster_meta_entry_id)
 
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
-        r.raise_for_status()
         parent_raster = r.json().get('parent_raster', {})
         images = parent_raster.get('image_set', {}).get('images', [])
         try:
@@ -144,7 +138,6 @@ class Rgdc:
             raster_meta_entry_id = spatial_subentry_id(raster_meta_entry_id)
 
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
-        r.raise_for_status()
         parent_raster = r.json().get('parent_raster', {})
 
         # Create dirs after request to avoid empty dirs if failed

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -129,7 +129,7 @@ class Rgdc:
             raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry, or search result.
             pathname: The directory to download the image set to. If not supplied, a temporary directory will be used.
             nest_with_name: If True, nests the download within an additional directory, using the raster entry name.
-            keep_existing: If False, replace files existing on disk
+            keep_existing: If False, replace files existing on disk. Only valid if `pathname` is given.
 
         Returns:
             A dictionary of the paths to all files downloaded under the directory.

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -222,11 +222,11 @@ class Rgdc:
             resolution: The min/max resolution of the raster.
             cloud_cover: The min/max cloud coverage of the raster.
             frame_rate: The min/max frame rate of the video.
-            limit: The maximum number of results to return. Default: all.
+            limit: The maximum number of results to return.
             offset: The number of results to skip.
 
         Returns:
-            A list of Spatial Entries.
+            An list of Spatial Entries.
         """
         # The dict that will be used to store params.
         # Initialize with queries that won't be additionally processed.
@@ -295,20 +295,6 @@ class Rgdc:
             params['frame_rate_min'] = frmin
             params['frame_rate_max'] = frmax
 
-        results = []
         response = self.session.get('geosearch', params=params)
         response.raise_for_status()
-        last_results = response.json()['results']
-        results.extend(last_results)
-
-        # scroll through all pages
-        if limit is None:
-            params['offset'] += len(last_results)
-            while last_results:
-                response = self.session.get('geosearch', params=params)
-                response.raise_for_status()
-                last_results = response.json()['results']
-                results.extend(last_results)
-                params['offset'] += len(last_results)
-
-        return results
+        return [result for result in response.json()['results']]

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -88,21 +88,30 @@ class Rgdc:
         r.raise_for_status()
         return r.content
 
+    def _id(self, search_result):
+        """
+        Helper function to get the id of a returned SpatialEntry
+        """
+        return search_result['subentry_pk']
+
     def download_raster_entry_thumbnail(
         self,
-        raster_meta_entry_id: Union[str, int],
+        raster_meta_entry_id: Union[str, int, dict],
         band: int = 0,
     ) -> bytes:
         """
         Download the generated thumbnail for this ImageEntry.
 
         Args:
-            raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry.
+            raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry, or search result.
             band: The index of the image in the raster's image set to produce thumbnail from.
 
         Returns:
             Thumbnail bytes.
         """
+        if isinstance(raster_meta_entry_id, dict):
+            raster_meta_entry_id = self._id(raster_meta_entry_id)
+
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
         r.raise_for_status()
         parent_raster = r.json().get('parent_raster', {})
@@ -114,7 +123,7 @@ class Rgdc:
 
     def download_raster_entry(
         self,
-        raster_meta_entry_id: Union[str, int],
+        raster_meta_entry_id: Union[str, int, dict],
         pathname: Optional[str] = None,
         nest_with_name: bool = False,
         overwrite: bool = False,
@@ -123,7 +132,7 @@ class Rgdc:
         Download the image set associated with a raster entry to disk.
 
         Args:
-            raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry.
+            raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry, or search result.
             pathname: The directory to download the image set to. If not supplied, a temporary directory will be used.
             nest_with_name: If True, nests the download within an additional directory, using the raster entry name.
             overwrite: If True, replace files existing on disk
@@ -131,6 +140,9 @@ class Rgdc:
         Returns:
             A dictionary of the paths to all files downloaded under the directory.
         """
+        if isinstance(raster_meta_entry_id, dict):
+            raster_meta_entry_id = self._id(raster_meta_entry_id)
+
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
         r.raise_for_status()
         parent_raster = r.json().get('parent_raster', {})

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from geomet import wkt
 from tqdm import tqdm
 
-from .session import RgdcSession
+from .session import retry_RgdcSession
 from .types import DATETIME_OR_STR_TUPLE, SEARCH_DATATYPE_CHOICE, SEARCH_PREDICATE_CHOICE
 from .utils import DEFAULT_RGD_API, datetime_to_str, download_checksum_file_to_path
 
@@ -44,7 +44,7 @@ class Rgdc:
             encoded_credentials = b64encode(f'{username}:{password}'.encode('utf-8')).decode()
             auth_header = f'Basic {encoded_credentials}'
 
-        self.session = RgdcSession(base_url=api_url, auth_header=auth_header)
+        self.session = retry_RgdcSession(base_url=api_url, auth_header=auth_header)
 
     def list_image_entry_tiles(self, image_entry_id: Union[str, int]) -> Dict:
         """List geodata imagery image_entry tiles."""

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from geomet import wkt
 from tqdm import tqdm
 
-from .session import retry_RgdcSession
+from .session import retry_rgdcsession
 from .types import DATETIME_OR_STR_TUPLE, SEARCH_DATATYPE_CHOICE, SEARCH_PREDICATE_CHOICE
 from .utils import (
     DEFAULT_RGD_API,
@@ -49,7 +49,7 @@ class Rgdc:
             encoded_credentials = b64encode(f'{username}:{password}'.encode('utf-8')).decode()
             auth_header = f'Basic {encoded_credentials}'
 
-        self.session = retry_RgdcSession(base_url=api_url, auth_header=auth_header)
+        self.session = retry_rgdcsession(base_url=api_url, auth_header=auth_header)
 
     def list_image_entry_tiles(self, image_entry_id: Union[str, int]) -> Dict:
         """List geodata imagery image_entry tiles."""

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from geomet import wkt
 from tqdm import tqdm
 
-from .session import retry_rgdcsession
+from .session import RgdcSession
 from .types import DATETIME_OR_STR_TUPLE, SEARCH_DATATYPE_CHOICE, SEARCH_PREDICATE_CHOICE
 from .utils import (
     DEFAULT_RGD_API,
@@ -50,7 +50,7 @@ class Rgdc:
             encoded_credentials = b64encode(f'{username}:{password}'.encode('utf-8')).decode()
             auth_header = f'Basic {encoded_credentials}'
 
-        self.session = retry_rgdcsession(base_url=api_url, auth_header=auth_header)
+        self.session = RgdcSession(base_url=api_url, auth_header=auth_header)
 
     def list_image_entry_tiles(self, image_entry_id: Union[str, int]) -> Dict:
         """List geodata imagery image_entry tiles."""

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -117,6 +117,7 @@ class Rgdc:
         raster_meta_entry_id: Union[str, int],
         pathname: Optional[str] = None,
         nest_with_name: bool = False,
+        overwrite: bool = False,
     ) -> RasterDownload:
         """
         Download the image set associated with a raster entry to disk.
@@ -125,6 +126,7 @@ class Rgdc:
             raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry.
             pathname: The directory to download the image set to. If not supplied, a temporary directory will be used.
             nest_with_name: If True, nests the download within an additional directory, using the raster entry name.
+            overwrite: If True, replace files existing on disk
 
         Returns:
             A dictionary of the paths to all files downloaded under the directory.
@@ -155,14 +157,14 @@ class Rgdc:
         images = parent_raster.get('image_set', {}).get('images', [])
         for image in tqdm(images, desc='Downloading image files'):
             file = image.get('image_file', {}).get('file', {})
-            file_path = download_checksum_file_to_path(file, path)
+            file_path = download_checksum_file_to_path(file, path, overwrite=overwrite)
             if file_path:
                 raster_download.images.append(file_path)
 
         # Download ancillary files
         ancillary = parent_raster.get('ancillary_files', [])
         for file in tqdm(ancillary, desc='Downloading ancillary files'):
-            file_path = download_checksum_file_to_path(file, path)
+            file_path = download_checksum_file_to_path(file, path, overwrite=overwrite)
             if file_path:
                 raster_download.ancillary.append(file_path)
 

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -94,9 +94,7 @@ class Rgdc:
         return r.content
 
     def _id(self, search_result):
-        """
-        Helper function to get the id of a returned SpatialEntry
-        """
+        """Get the id of a returned SpatialEntry."""
         return search_result['subentry_pk']
 
     def download_raster_entry_thumbnail(

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -16,6 +16,7 @@ from .utils import (
     datetime_to_str,
     download_checksum_file_to_path,
     limit_offset_pager,
+    spatial_subentry_id,
 )
 
 
@@ -93,10 +94,6 @@ class Rgdc:
         r.raise_for_status()
         return r.content
 
-    def _id(self, search_result):
-        """Get the id of a returned SpatialEntry."""
-        return search_result['subentry_pk']
-
     def download_raster_entry_thumbnail(
         self,
         raster_meta_entry_id: Union[str, int, dict],
@@ -113,7 +110,7 @@ class Rgdc:
             Thumbnail bytes.
         """
         if isinstance(raster_meta_entry_id, dict):
-            raster_meta_entry_id = self._id(raster_meta_entry_id)
+            raster_meta_entry_id = spatial_subentry_id(raster_meta_entry_id)
 
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
         r.raise_for_status()
@@ -144,7 +141,7 @@ class Rgdc:
             A dictionary of the paths to all files downloaded under the directory.
         """
         if isinstance(raster_meta_entry_id, dict):
-            raster_meta_entry_id = self._id(raster_meta_entry_id)
+            raster_meta_entry_id = spatial_subentry_id(raster_meta_entry_id)
 
         r = self.session.get(f'geodata/imagery/raster/{raster_meta_entry_id}')
         r.raise_for_status()

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -208,11 +208,11 @@ class Rgdc:
             resolution: The min/max resolution of the raster.
             cloud_cover: The min/max cloud coverage of the raster.
             frame_rate: The min/max frame rate of the video.
-            limit: The maximum number of results to return.
+            limit: The maximum number of results to return. Default: all.
             offset: The number of results to skip.
 
         Returns:
-            An list of Spatial Entries.
+            A list of Spatial Entries.
         """
         # The dict that will be used to store params.
         # Initialize with queries that won't be additionally processed.
@@ -281,6 +281,20 @@ class Rgdc:
             params['frame_rate_min'] = frmin
             params['frame_rate_max'] = frmax
 
+        results = []
         response = self.session.get('geosearch', params=params)
         response.raise_for_status()
-        return [result for result in response.json()['results']]
+        last_results = response.json()['results']
+        results.extend(last_results)
+
+        # scroll through all pages
+        if limit is None:
+            params['offset'] += len(last_results)
+            while last_results:
+                response = self.session.get('geosearch', params=params)
+                response.raise_for_status()
+                last_results = response.json()['results']
+                results.extend(last_results)
+                params['offset'] += len(last_results)
+
+        return results

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -54,7 +54,7 @@ class Rgdc:
 
     def list_image_entry_tiles(self, image_entry_id: Union[str, int]) -> Dict:
         """List geodata imagery image_entry tiles."""
-        r = self.session.get(f'geodata/imagery/{image_entry_id}/tiles')
+        r = self.session.get(f'geoprocess/imagery/{image_entry_id}/tiles')
         return r.json()
 
     def download_image_entry_file(

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -126,7 +126,7 @@ class Rgdc:
         raster_meta_entry_id: Union[str, int, dict],
         pathname: Optional[str] = None,
         nest_with_name: bool = False,
-        overwrite: bool = False,
+        keep_existing: bool = True,
     ) -> RasterDownload:
         """
         Download the image set associated with a raster entry to disk.
@@ -135,7 +135,7 @@ class Rgdc:
             raster_meta_entry_id: The id of the RasterMetaEntry, which is a child to the desired raster entry, or search result.
             pathname: The directory to download the image set to. If not supplied, a temporary directory will be used.
             nest_with_name: If True, nests the download within an additional directory, using the raster entry name.
-            overwrite: If True, replace files existing on disk
+            keep_existing: If False, replace files existing on disk
 
         Returns:
             A dictionary of the paths to all files downloaded under the directory.
@@ -169,14 +169,14 @@ class Rgdc:
         images = parent_raster.get('image_set', {}).get('images', [])
         for image in tqdm(images, desc='Downloading image files'):
             file = image.get('image_file', {}).get('file', {})
-            file_path = download_checksum_file_to_path(file, path, overwrite=overwrite)
+            file_path = download_checksum_file_to_path(file, path, keep_existing=keep_existing)
             if file_path:
                 raster_download.images.append(file_path)
 
         # Download ancillary files
         ancillary = parent_raster.get('ancillary_files', [])
         for file in tqdm(ancillary, desc='Downloading ancillary files'):
-            file_path = download_checksum_file_to_path(file, path, overwrite=overwrite)
+            file_path = download_checksum_file_to_path(file, path, keep_existing=keep_existing)
             if file_path:
                 raster_download.ancillary.append(file_path)
 

--- a/rgdc/rgdc/session.py
+++ b/rgdc/rgdc/session.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from requests_toolbelt.sessions import BaseUrlSession
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from requests_toolbelt.sessions import BaseUrlSession
 
 from .version import __version__
 
@@ -28,7 +28,7 @@ class RgdcSession(BaseUrlSession):
             self.headers['Authorization'] = auth_header
 
 
-def retry_RgdcSession(*args, retries: Optional[int] = 5, **kwargs):
+def retry_rgdcsession(*args, retries: Optional[int] = 5, **kwargs):
     """
     Initialize a session with a ResonantGeoData server with automatic retries.
 

--- a/rgdc/rgdc/session.py
+++ b/rgdc/rgdc/session.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from requests import Response
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from requests_toolbelt.sessions import BaseUrlSession
@@ -40,3 +41,10 @@ class RgdcSession(BaseUrlSession):
         adapter = HTTPAdapter(max_retries=retry)
         self.mount('https://', adapter)
         self.mount('http://', adapter)
+
+        # Define hook to assert that a request succeeded
+        def assert_status_hook(response: Response, *args, **kwargs):
+            response.raise_for_status()
+
+        # Response field is present by default
+        self.hooks['response'].append(assert_status_hook)

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -41,13 +41,14 @@ def datetime_to_str(value: object):
     return value
 
 
-def download_checksum_file_to_path(file: Dict, path: Path):
+def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
     """
     Download a RGD ChecksumFile to a given path.
 
     Args:
         file: A RGD ChecksumFile serialized as a Dict.
         path: The root path to download this file to.
+        overwrite: if True, replace files existing on disk
 
     Returns:
         The path on disk the file was downloaded to.
@@ -72,8 +73,9 @@ def download_checksum_file_to_path(file: Dict, path: Path):
 
     # Download contents to file
     file_path = parent_path / filename
-    with open(file_path, 'wb') as open_file_path:
-        for chunk in iterate_response_bytes(file_download_url):
-            open_file_path.write(chunk)
+    if not file_path.is_file() or overwrite:
+        with open(file_path, 'wb') as open_file_path:
+            for chunk in iterate_response_bytes(file_download_url):
+                open_file_path.write(chunk)
 
     return file_path

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -79,14 +79,14 @@ def datetime_to_str(value: object):
     return value
 
 
-def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
+def download_checksum_file_to_path(file: Dict, path: Path, keep_existing: bool):
     """
     Download a RGD ChecksumFile to a given path.
 
     Args:
         file: A RGD ChecksumFile serialized as a Dict.
         path: The root path to download this file to.
-        overwrite: If True, replace files existing on disk.
+        keep_existing: If False, replace files existing on disk.
 
     Returns:
         The path on disk the file was downloaded to.
@@ -111,7 +111,7 @@ def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
 
     # Download contents to file
     file_path = parent_path / filename
-    if not file_path.is_file() or overwrite:
+    if not (file_path.is_file() and keep_existing):
         with open(file_path, 'wb') as open_file_path:
             for chunk in iterate_response_bytes(file_download_url):
                 open_file_path.write(chunk)

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -119,6 +119,6 @@ def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
     return file_path
 
 
-def spatial_subentry_id(self, search_result):
+def spatial_subentry_id(search_result):
     """Get the id of a returned SpatialEntry."""
     return search_result['subentry_pk']

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -117,3 +117,8 @@ def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
                 open_file_path.write(chunk)
 
     return file_path
+
+
+def spatial_subentry_id(self, search_result):
+    """Get the id of a returned SpatialEntry."""
+    return search_result['subentry_pk']

--- a/rgdc/rgdc/utils.py
+++ b/rgdc/rgdc/utils.py
@@ -86,7 +86,7 @@ def download_checksum_file_to_path(file: Dict, path: Path, overwrite: bool):
     Args:
         file: A RGD ChecksumFile serialized as a Dict.
         path: The root path to download this file to.
-        overwrite: if True, replace files existing on disk
+        overwrite: If True, replace files existing on disk.
 
     Returns:
         The path on disk the file was downloaded to.


### PR DESCRIPTION
This MR contains 3 small improvements to `rgdc.Rgdc`.

1. Add 5 automatic retries on all GET requests. This is to guard against random 503 errors from rate-limiting that would be fixed by simply rerunning the command. The implementation is to bake this into the `Session` object; see https://www.peterbe.com/plog/best-practice-with-retries-with-requests for the approach.
2. Add `overwrite=False` kwarg to `download_raster_entry`. This will skip files already on disk - handy for speeding up tests and making scripts idempotent.
3. Perhaps a more controversial one: let `download_raster_entry` and `download_raster_entry_thumbnail` directly parse a dict returned by `search` to find the `id`, rather than the user having to make another request manually as in the README example or study that dict to find it. 
I believe this will improve usability for the current use cases, as the users of this client should need to know as little as possible about the internals of RGD's data representation (and web programming in general, for that matter) to get started. But I am open to ideas to implement this in a more principled and future-proof way.