### PR TITLE
Cleanup rgdc function names

### DIFF
--- a/.github/workflows/rgdc.yml
+++ b/.github/workflows/rgdc.yml
@@ -28,8 +28,8 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         working-directory: ./rgdc
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           python setup.py sdist bdist_wheel
           twine upload --skip-existing dist/*

--- a/.github/workflows/rgdc.yml
+++ b/.github/workflows/rgdc.yml
@@ -1,0 +1,35 @@
+name: rgdc python client
+on:
+  push:
+    branches: "*"
+    tags: "v*"
+  pull_request:
+    branches: "**"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Install rgdc
+        working-directory: ./rgdc
+        run: pip install -e .
+      - name: Test (not implemented)
+        working-directory: ./rgdc
+        run: python -c "from rgdc import Rgdc; print('Import went okay!')"
+      - name: Build and Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        working-directory: ./rgdc
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload --skip-existing dist/*

--- a/rgdc/README.md
+++ b/rgdc/README.md
@@ -62,7 +62,7 @@ load_image = lambda imbytes: imageio.imread(BytesIO(imbytes))
 
 count = len(raster['parent_raster']['image_set']['images'])
 for i in range(count):
-    thumb_bytes = client.download_raster_entry_thumbnail(q[0], band=i)
+    thumb_bytes = client.download_raster_thumbnail(q[0], band=i)
     thumb = load_image(thumb_bytes)
     plt.subplot(1, count, i+1)
     plt.imshow(thumb)
@@ -76,7 +76,7 @@ plt.show()
 import rasterio
 from rasterio.plot import show
 
-paths = client.download_raster_entry(q[0])
+paths = client.download_raster(q[0])
 rasters = [rasterio.open(im) for im in paths.images]
 for i, src in enumerate(rasters):
     plt.subplot(1, count, i+1)


### PR DESCRIPTION
For #352: removes the `_entry` notation from the API

Resolve #349: adds a CI routine to "test" the client API and publish it to PyPI on tags