### PR TITLE
User admin approval on sign up

### DIFF
--- a/rgd/geodata/actions.py
+++ b/rgd/geodata/actions.py
@@ -95,3 +95,19 @@ def clean_empty_rasters(modeladmin, request, queryset):
     for raster in queryset.all():
         if len(raster.image_set.images) < 1:
             raster.image_set.delete()
+
+
+def make_users_active(modeladmin, request, queryset):
+    """Make each user active."""
+    for user in queryset.all():
+        if not user.is_active:
+            user.is_active = True
+            user.save(update_fields=['is_active'])
+
+
+def make_users_staff(modeladmin, request, queryset):
+    """Make each user staff."""
+    for user in queryset.all():
+        if not user.is_staff:
+            user.is_staff = True
+            user.save(update_fields=['is_staff'])

--- a/rgd/geodata/admin.py
+++ b/rgd/geodata/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
 from django.contrib.gis.admin import OSMGeoAdmin
 
 from . import actions
@@ -35,6 +37,23 @@ TASK_EVENT_READONLY = (
     'failure_reason',
     'status',
 )
+
+admin.site.unregister(User)
+
+
+@admin.register(User)
+class CustomUserAdmin(UserAdmin):
+    actions = [
+        actions.make_users_active,
+        actions.make_users_staff,
+    ]
+
+    list_display = (
+        'username',
+        'is_staff',
+        'is_superuser',
+        'is_active',
+    )
 
 
 class _FileGetNameMixin:

--- a/rgd/geodata/signals.py
+++ b/rgd/geodata/signals.py
@@ -1,6 +1,7 @@
 from functools import wraps
 import os
 
+from allauth.account.signals import user_signed_up
 from django.db import transaction
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
@@ -109,3 +110,10 @@ def _post_delete_converted_image_file(sender, instance, *args, **kwargs):
 @skip_signal()
 def _post_delete_subsampled_image(sender, instance, *args, **kwargs):
     transaction.on_commit(lambda: instance._post_delete(*args, **kwargs))
+
+
+@receiver(user_signed_up)
+def set_new_user_inactive(sender, **kwargs):
+    user = kwargs.get('user')
+    user.is_active = False
+    user.save(update_fields=['is_active'])


### PR DESCRIPTION
Adds an admin user approval process for all new sign ups

This sets every user's `is_active` status to `False` on account sign-up. An admin will have to go into the admin portal and select which user to make active manually. To make this easier, I added admin actions to do this in bulk