### PR TITLE
Add password prompt to Rgdc class constructor

### DIFF
--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 from dataclasses import dataclass
+import getpass
 import json
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -28,6 +29,18 @@ class RasterDownload:
 
 
 class Rgdc:
+    @classmethod
+    def from_login_prompt(cls, *args, **kwargs):
+        """
+        Return an authenticated Rgdc instance from a login prompt.
+
+        Accepts the same positional/keyword arguments as the class constructor EXCEPT for `username` and `password`.
+        """
+        username = input('Username: ')
+        password = getpass.getpass()
+
+        return cls(*args, **kwargs, username=username, password=password)
+
     def __init__(
         self,
         api_url: str = DEFAULT_RGD_API,

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -29,18 +29,6 @@ class RasterDownload:
 
 
 class Rgdc:
-    @classmethod
-    def from_login_prompt(cls, *args, **kwargs):
-        """
-        Return an authenticated Rgdc instance from a login prompt.
-
-        Accepts the same positional/keyword arguments as the class constructor EXCEPT for `username` and `password`.
-        """
-        username = input('Username: ')
-        password = getpass.getpass()
-
-        return cls(*args, **kwargs, username=username, password=password)
-
     def __init__(
         self,
         api_url: str = DEFAULT_RGD_API,
@@ -59,6 +47,11 @@ class Rgdc:
             A new Rgdc instance.
         """
         auth_header = None
+
+        # Prompt for password if not provided
+        if username is not None and password is None:
+            password = getpass.getpass()
+
         if username and password:
             encoded_credentials = b64encode(f'{username}:{password}'.encode('utf-8')).decode()
             auth_header = f'Basic {encoded_credentials}'

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -41,7 +41,7 @@ class Rgdc:
         Args:
             api_url: The base url of the RGD API instance.
             username: The username to authenticate to the instance with, if any.
-            password: The password associated with the provided username.
+            password: The password associated with the provided username. If None, a prompt will be provided.
 
         Returns:
             A new Rgdc instance.


### PR DESCRIPTION
This adds the ability to create an authenticated client instance, without needing to specify your username/password in plain text.