### PR TITLE
Attempt fix watch subdomain

### DIFF
--- a/terraform/watch.tf
+++ b/terraform/watch.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "www-watch" {
 
   alias {
     name                   = "RDG-ELB1-758710195.us-west-2.elb.amazonaws.com"
-    zone_id                = "us-west-2-lax-1a"
+    zone_id                = "Z1H1FL5HABSF5"
     evaluate_target_health = true
   }
 }

--- a/terraform/watch.tf
+++ b/terraform/watch.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "www-watch" {
 
   alias {
     name                   = "RDG-ELB1-758710195.us-west-2.elb.amazonaws.com"
-    zone_id                = "us-west-2"
+    zone_id                = "us-west-2-lax-1a"
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
Fixing error on TF: https://app.terraform.io/app/ResonantGeoData/workspaces/ResonantGeoData/runs/run-o42QXWUxzrBAoVej

This is one of the zones for `us-west-2`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions