### PR TITLE
Fix outline transform for rasters

### DIFF
--- a/rgd/geodata/management/commands/_data_helper.py
+++ b/rgd/geodata/management/commands/_data_helper.py
@@ -13,6 +13,7 @@ from django.utils.timezone import make_aware
 
 from rgd.geodata import models
 from rgd.geodata.datastore import datastore
+from rgd.geodata.models.imagery import etl
 from rgd.utility import get_or_create_no_commit
 
 logger = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ def load_image_files(image_files):
     return ids
 
 
-def load_raster(pks, raster_dict):
+def load_raster(pks, raster_dict, footprint=False):
     if not isinstance(pks, (list, tuple)):
         pks = [
             pks,
@@ -193,17 +194,19 @@ def load_raster(pks, raster_dict):
                 'instrumentation',
             ]
         )
+    if footprint:
+        etl.populate_raster_footprint(raster.id)
     return raster
 
 
-def load_raster_files(raster_dicts):
+def load_raster_files(raster_dicts, footprint=False):
     ids = []
     count = len(raster_dicts)
     for i, rf in enumerate(raster_dicts):
         logger.info(f'Processesing raster {i+1} of {count}')
         start_time = datetime.now()
         imentries = load_image_files(rf.get('images'))
-        raster = load_raster(imentries, rf)
+        raster = load_raster(imentries, rf, footprint=footprint)
         ids.append(raster.pk)
         logger.info('\t Loaded raster in: {}'.format(datetime.now() - start_time))
     return ids

--- a/rgd/geodata/management/commands/demo_data.py
+++ b/rgd/geodata/management/commands/demo_data.py
@@ -54,10 +54,23 @@ RASTER_URLS = []
 class Command(helper.SynchronousTasksCommand):
     help = 'Populate database with demo data.'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-f',
+            '--footprint',
+            action='store_true',
+            default=False,
+            help='Compute the valid data footprints',
+        )
+
     def handle(self, *args, **options):
+        footprint = options.get('footprint')
+
         self.set_synchronous()
         # Run the command
-        helper.load_raster_files([helper.make_raster_dict(im) for im in RASTER_FILES])
+        helper.load_raster_files(
+            [helper.make_raster_dict(im) for im in RASTER_FILES], footprint=footprint
+        )
         helper.load_shape_files(SHAPE_FILES)
         helper.load_fmv_files(FMV_FILES)
         helper.load_kwcoco_archives(KWCOCO_ARCHIVES)

--- a/rgd/geodata/management/commands/s3_landsat.py
+++ b/rgd/geodata/management/commands/s3_landsat.py
@@ -42,6 +42,13 @@ class Command(helper.SynchronousTasksCommand):
         parser.add_argument(
             '-g', '--get_count', help='Use to fetch the number of available rasters.'
         )
+        parser.add_argument(
+            '-f',
+            '--footprint',
+            action='store_true',
+            default=False,
+            help='Compute the valid data footprints',
+        )
 
     def handle(self, *args, **options):
         self.set_synchronous()
@@ -52,8 +59,9 @@ class Command(helper.SynchronousTasksCommand):
             return
 
         count = options.get('count', 0)
+        footprint = options.get('footprint')
 
         # Run the command
-        helper.load_raster_files(_get_landsat_urls(count))
+        helper.load_raster_files(_get_landsat_urls(count), footprint=footprint)
         self.stdout.write(self.style.SUCCESS(SUCCESS_MSG))
         self.reset_celery()

--- a/rgd/geodata/models/imagery/etl.py
+++ b/rgd/geodata/models/imagery/etl.py
@@ -176,7 +176,7 @@ def _get_valid_data_footprint(src, band_num):
     if not src.nodata:
         workdir = getattr(settings, 'GEODATA_WORKDIR', None)
         with tempfile.TemporaryDirectory(dir=workdir) as tmpdir:
-            output_path = os.path.join(tmpdir, os.path.basename(src.name))
+            output_path = os.path.join(tmpdir, 'temp')
             rasterio.shutil.copy(src, output_path, driver=src.driver)
             with rasterio.open(output_path, 'r+') as src:
                 src.nodata = 0

--- a/rgd/geodata/models/imagery/etl.py
+++ b/rgd/geodata/models/imagery/etl.py
@@ -139,8 +139,7 @@ def _extract_raster_outline(src):
             (src.bounds.left, src.bounds.top),  # Close the loop
         )
     )
-
-    return transform_geometry(Polygon(coords, srid=src.crs.to_epsg()), src.crs.to_epsg())
+    return transform_geometry(Polygon(coords, srid=src.crs.to_epsg()), src.crs.to_wkt())
 
 
 def _extract_raster_meta(image_file_entry):

--- a/rgd/geodata/models/imagery/etl.py
+++ b/rgd/geodata/models/imagery/etl.py
@@ -347,15 +347,11 @@ def populate_raster_entry(raster_entry):
                 'name',
             ]
         )
-    footprint = meta.pop('footprint')
     raster_meta, created = get_or_create_no_commit(RasterMetaEntry, parent_raster=raster_entry)
     # Not using `defaults` here because we want `meta` to always get updated.
     for k, v in meta.items():
         # Yeah. This is sketchy, but it works.
         setattr(raster_meta, k, v)
-    if not raster_meta.footprint:
-        # Only set if not already set since this func defaults it to using outline
-        raster_meta.footprint = footprint
     raster_meta.save()
     return True
 

--- a/rgd/geodata/templates/geodata/_includes/empty_viewer.html
+++ b/rgd/geodata/templates/geodata/_includes/empty_viewer.html
@@ -35,10 +35,12 @@
       node: '#map',
       clampBoundsX: true
     })
-    basemapLayer = map.createLayer('osm', {
+    var basemapLayer = map.createLayer('osm', {
       source: getCookie('basemapChoice', 'osm'),
       gcs: 'EPSG:3857' // web mercator
     });
+
+    var tileLayer = map.createLayer('osm', {keepLower: false, attribution: ''});
 
     // Increase zoom range from default of 16
     map.zoomRange({

--- a/rgd/geodata/templates/geodata/rastermetaentry_detail.html
+++ b/rgd/geodata/templates/geodata/rastermetaentry_detail.html
@@ -48,7 +48,7 @@
 
   <div class="slidecontainer">
     <label for="rasterOpacityRange">Raster Layer Opacity: </label>
-    <input type="range" min="1" max="100" value="75" class="slider" id="rasterOpacityRange" onChange="updateTilesOpacity(event, value)">
+    <input type="range" min="1" max="100" value="100" class="slider" id="rasterOpacityRange" onChange="updateTilesOpacity(event, value)">
   </div>
 
   <div class="thumbnailContainer">
@@ -66,14 +66,11 @@
     let extents = JSON.parse('{{ extents|escapejs }}');
     var outline = JSON.parse(extents['outline'])["coordinates"][0]
 
-    var tiles = map.createLayer('osm', {keepLower: false, attribution: ''});
-    tiles.opacity(0.75)
-
     // Make sure regions outside the extent of the raster do not load null tiles
     //   this relieves strain on the tile server
     const dataset_bb = extents.extent;
-    tiles.isValid = (index) => {
-      const tileBounds = tiles.gcsTileBounds(index);
+    tileLayer.isValid = (index) => {
+      const tileBounds = tileLayer.gcsTileBounds(index);
       return tileBounds.left <= dataset_bb.xmax &&
         tileBounds.right >= dataset_bb.xmin &&
         tileBounds.top >= dataset_bb.ymin &&
@@ -86,21 +83,21 @@
       var image_id = Number(selector.value);
       console.log(image_id)
       if (image_id >= 0) {
-        tiles.visible(true)
-        tiles.url(`${host}/api/geoprocess/imagery/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
+        tileLayer.visible(true)
+        tileLayer.url(`${host}/api/geoprocess/imagery/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
         thumbnail.src = `${host}/api/geoprocess/imagery/${image_id}/thumbnail`
         thumbnail.hidden = false
       } else {
-        tiles.visible(false)
+        tileLayer.visible(false)
         thumbnail.hidden = true
       }
-      // TODO: clear tiles when `none` is selected
+      // TODO: clear tileLayer when `none` is selected
     }
     updateBandThumbnail()
 
     function updateTilesOpacity(e, value) {
       value = Number(value) / 100.0;
-      tiles.opacity(value);
+      tileLayer.opacity(value);
     }
 
     // Add collected polygons to map

--- a/rgd/geodata/tests/test_imagery.py
+++ b/rgd/geodata/tests/test_imagery.py
@@ -15,13 +15,13 @@ from rgd.geodata.models.imagery.subsample import populate_subsampled_image
 from . import factories
 
 SampleFiles = [
-    {'name': '20091021202517-01000100-VIS_0001.ntf', 'centroid': {'x': -84.111, 'y': 39.781}},
-    {'name': 'aerial_rgba_000003.tiff', 'centroid': {'x': -122.005, 'y': 37.336}},
-    {'name': 'cclc_schu_100.tif', 'centroid': {'x': -76.852, 'y': 42.402}},
-    {'name': 'landcover_sample_2000.tif', 'centroid': {'x': -75.228, 'y': 42.955}},
-    {'name': 'paris_france_10.tiff', 'centroid': {'x': 2.549, 'y': 49.004}},
-    {'name': 'rgb_geotiff.tiff', 'centroid': {'x': -117.189, 'y': 33.169}},
-    {'name': 'RomanColosseum_WV2mulitband_10.tif', 'centroid': {'x': 12.492, 'y': 41.890}},
+    {'name': '20091021202517-01000100-VIS_0001.ntf', 'centroid': {'x': -84.11, 'y': 39.78}},
+    {'name': 'aerial_rgba_000003.tiff', 'centroid': {'x': -122.01, 'y': 37.34}},
+    {'name': 'cclc_schu_100.tif', 'centroid': {'x': -76.85, 'y': 42.40}},
+    {'name': 'landcover_sample_2000.tif', 'centroid': {'x': -75.35, 'y': 42.96}},
+    {'name': 'paris_france_10.tiff', 'centroid': {'x': 2.55, 'y': 49.00}},
+    {'name': 'rgb_geotiff.tiff', 'centroid': {'x': -117.19, 'y': 33.17}},
+    {'name': 'RomanColosseum_WV2mulitband_10.tif', 'centroid': {'x': 12.50, 'y': 41.89}},
 ]
 
 # These test files are dramatically downsampled for rapid testing
@@ -30,6 +30,8 @@ LandsatFiles = [
     'LC08_L1TP_034032_20200429_20200509_01_T1_sr_band2.tif',
     'LC08_L1TP_034032_20200429_20200509_01_T1_sr_band3.tif',
 ]
+
+TOLERANCE = 2e-2
 
 
 def _make_raster_from_datastore(name):
@@ -53,8 +55,8 @@ def test_imagefile_to_rasterentry_centroids(testfile):
     raster = _make_raster_from_datastore(testfile['name'])
     meta = raster.rastermetaentry
     centroid = meta.outline.centroid
-    assert centroid.x == pytest.approx(testfile['centroid']['x'], abs=2e-3)
-    assert centroid.y == pytest.approx(testfile['centroid']['y'], abs=2e-3)
+    assert centroid.x == pytest.approx(testfile['centroid']['x'], abs=TOLERANCE)
+    assert centroid.y == pytest.approx(testfile['centroid']['y'], abs=TOLERANCE)
 
 
 @pytest.mark.parametrize('testfile', SampleFiles)
@@ -77,8 +79,8 @@ def test_imagefile_url_to_rasterentry_centroids(testfile):
     # Sanity check
     assert imagefile.file.type == FileSourceType.URL
     # Make sure the file contents were read correctly
-    assert centroid.x == pytest.approx(testfile['centroid']['x'], abs=2e-3)
-    assert centroid.y == pytest.approx(testfile['centroid']['y'], abs=2e-3)
+    assert centroid.x == pytest.approx(testfile['centroid']['x'], abs=TOLERANCE)
+    assert centroid.y == pytest.approx(testfile['centroid']['y'], abs=TOLERANCE)
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
This fixes an issue when computing the outline of rasters. Previously, the transform was done incorrectly and would lead to errors in larger images. Here is an example with Landsat imagery:

| `master` | this branch |
|---|---|
|  ![Screen Shot 2021-05-05 at 8 53 54 AM](https://user-images.githubusercontent.com/22067021/117171381-0cfd0c80-ad88-11eb-920f-48395392f2ac.png) |  ![Screen Shot 2021-05-05 at 9 56 15 AM](https://user-images.githubusercontent.com/22067021/117171576-387ff700-ad88-11eb-83ee-5045bf23bc32.png) |


Further, I am working to resolve an issue when computing the valid data mask (`footprint`) when the `nodata` is set to `None`

resolves #372 