### PR TITLE
STAC serializer (renderer) for RasterMetaEntry

### DIFF
--- a/rgd/geodata/api/get.py
+++ b/rgd/geodata/api/get.py
@@ -56,6 +56,12 @@ class GetRasterMetaEntry(RetrieveAPIView, _PermissionMixin):
     queryset = models.RasterMetaEntry.objects.all()
 
 
+class GetRasterMetaEntrySTAC(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.STACRasterSerializer
+    lookup_field = 'pk'
+    queryset = models.RasterMetaEntry.objects.all()
+
+
 class GetGeometryEntry(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.GeometryEntrySerializer
     lookup_field = 'pk'

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -1,5 +1,7 @@
 import json
 
+from geodata.models import geometry
+import pystac
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -210,6 +212,18 @@ class FMVEntryDataSerializer(FMVEntrySerializer):
     class Meta:
         model = models.FMVEntry
         fields = '__all__'
+
+
+class STACRasterSerializer(serializers.BaseSerializer):
+    def to_representation(self, instance: models.RasterMetaEntry) -> dict:
+        item = pystac.Item(
+            id=instance.pk,
+            geometry=instance.footprint.json,
+            bbox=instance.footprint.extent,
+            datetime=(instance.acquisition_date or instance.modified or instance.created),
+            properties={},
+        )
+        return item.to_dict()
 
 
 utility.make_serializers(globals(), models)

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -218,7 +218,7 @@ class STACRasterSerializer(serializers.BaseSerializer):
         item = pystac.Item(
             id=instance.pk,
             geometry=json.loads(instance.footprint.json),
-            bbox=instance.footprint.extent,
+            bbox=instance.extent,
             datetime=(instance.acquisition_date or instance.modified or instance.created),
             properties={},
         )

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -1,6 +1,5 @@
 import json
 
-from geodata.models import geometry
 import pystac
 from rest_framework import serializers
 from rest_framework.reverse import reverse

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -243,6 +243,10 @@ class STACRasterSerializer(serializers.BaseSerializer):
             epsg=CRS.from_proj4(instance.crs).to_epsg(),
             transform=instance.transform,
         )
+        # 'eo' extension
+        item.ext.enable('eo')
+        item.ext.eo.apply(cloud_cover=instance.cloud_cover, bands=[])
+
         return item.to_dict()
 
 

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -222,6 +222,13 @@ class STACRasterSerializer(serializers.BaseSerializer):
             datetime=(instance.acquisition_date or instance.modified or instance.created),
             properties={},
         )
+        # Add assets
+        for image_entry in instance.parent_raster.image_set.images.all():
+            asset = pystac.Asset(
+                href=image_entry.image_file.file.get_url(),
+                title=image_entry.image_file.file.name,
+            )
+            item.add_asset(f'image-{image_entry.pk}', asset)
         return item.to_dict()
 
 

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -1,5 +1,6 @@
 import json
 
+from pyproj import CRS
 import pystac
 from rest_framework import serializers
 from rest_framework.reverse import reverse
@@ -235,6 +236,13 @@ class STACRasterSerializer(serializers.BaseSerializer):
                 title=ancillary_file.name,
             )
             item.add_asset(f'ancillary-{ancillary_file.pk}', asset)
+        # 'proj' extension
+        item.ext.enable('projection')
+
+        item.ext.projection.apply(
+            epsg=CRS.from_proj4(instance.crs).to_epsg(),
+            transform=instance.transform,
+        )
         return item.to_dict()
 
 

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -218,7 +218,7 @@ class STACRasterSerializer(serializers.BaseSerializer):
     def to_representation(self, instance: models.RasterMetaEntry) -> dict:
         item = pystac.Item(
             id=instance.pk,
-            geometry=instance.footprint.json,
+            geometry=json.loads(instance.footprint.json),
             bbox=instance.footprint.extent,
             datetime=(instance.acquisition_date or instance.modified or instance.created),
             properties={},

--- a/rgd/geodata/serializers.py
+++ b/rgd/geodata/serializers.py
@@ -229,6 +229,12 @@ class STACRasterSerializer(serializers.BaseSerializer):
                 title=image_entry.image_file.file.name,
             )
             item.add_asset(f'image-{image_entry.pk}', asset)
+        for ancillary_file in instance.parent_raster.ancillary_files.all():
+            asset = pystac.Asset(
+                href=ancillary_file.get_url(),
+                title=ancillary_file.name,
+            )
+            item.add_asset(f'ancillary-{ancillary_file.pk}', asset)
         return item.to_dict()
 
 

--- a/rgd/geodata/urls.py
+++ b/rgd/geodata/urls.py
@@ -101,6 +101,11 @@ urlpatterns = [
         name='raster-meta-entry',
     ),
     path(
+        'api/geodata/imagery/raster/<int:pk>/stac',
+        api.get.GetRasterMetaEntrySTAC.as_view(),
+        name='raster-meta-entry-stac',
+    ),
+    path(
         'api/geodata/fmv/<int:pk>',
         api.get.GetFMVEntry.as_view(),
         name='fmv-entry',

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -121,6 +121,14 @@ class Rgdc:
         except IndexError:
             raise IndexError(f'Band index ({band}) out of range.')
 
+    def get_raster_stac(self, raster_meta_id: Union[str, int, dict]) -> Dict:
+        """Get raster entry as STAC item dictionary/JSON."""
+        if isinstance(raster_meta_id, dict):
+            raster_meta_id = spatial_subentry_id(raster_meta_id)
+
+        r = self.session.get(f'geodata/imagery/raster/{raster_meta_id}/stac')
+        return r.json()
+
     def download_raster(
         self,
         raster_meta_id: Union[str, int, dict],

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -122,10 +122,13 @@ class Rgdc:
             raise IndexError(f'Band index ({band}) out of range.')
 
     def get_raster(self, raster_meta_id: Union[str, int, dict], stac: bool = False) -> Dict:
-        """Get raster entry detail
+        """Get raster entry detail.
 
         Args:
             stac: Optionally return as STAC Item dictionary/JSON.
+
+        Returns:
+            Serialized object representation.
         """
         if isinstance(raster_meta_id, dict):
             raster_meta_id = spatial_subentry_id(raster_meta_id)

--- a/rgdc/rgdc/rgdc.py
+++ b/rgdc/rgdc/rgdc.py
@@ -121,12 +121,19 @@ class Rgdc:
         except IndexError:
             raise IndexError(f'Band index ({band}) out of range.')
 
-    def get_raster_stac(self, raster_meta_id: Union[str, int, dict]) -> Dict:
-        """Get raster entry as STAC item dictionary/JSON."""
+    def get_raster(self, raster_meta_id: Union[str, int, dict], stac: bool = False) -> Dict:
+        """Get raster entry detail
+
+        Args:
+            stac: Optionally return as STAC Item dictionary/JSON.
+        """
         if isinstance(raster_meta_id, dict):
             raster_meta_id = spatial_subentry_id(raster_meta_id)
 
-        r = self.session.get(f'geodata/imagery/raster/{raster_meta_id}/stac')
+        if stac:
+            r = self.session.get(f'geodata/imagery/raster/{raster_meta_id}/stac')
+        else:
+            r = self.session.get(f'geodata/imagery/raster/{raster_meta_id}')
         return r.json()
 
     def download_raster(

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'numpy',
         'pooch',
         'python-magic',
+        'pystac',
         'rules',
         'uritemplate',
         # Production-only


### PR DESCRIPTION
It describes the raster's 

- footprint
- bounding box
- related images
- ancillary files
- projection

E.g.:
```json
{
   "type":"Feature",
   "stac_version":"1.0.0-beta.2",
   "id":139,
   "properties":{
      "proj:epsg":32618,
      "proj:transform":[
         499980.0,
         20.0,
         0.0,
         4800000.0,
         0.0,
         -20.0
      ],
      "datetime":"2021-05-06T18:05:45.018503Z"
   },
   "geometry":{
      "type":"Polygon",
      "coordinates":[
         [
            [
               -75.00024679052602,
               43.35285539188815
            ],
            [
               -73.6455526700249,
               43.344834816006944
            ],
            [
               -73.66698539120085,
               42.356322389620374
            ],
            [
               -75.00024288390158,
               42.36407191996271
            ],
            [
               -75.00024679052602,
               43.35285539188815
            ]
         ]
      ]
   },
   "links":[
      
   ],
   "assets":{
      "image-133":{
         "href":"http://localhost:9000/rgd-storage/1f9254bc-ee20-4914-a944-8d04f5aee120/L1C_T18TWN_A028079_20201106T160014.tif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=mcovalt%2F20210506%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210506T195304Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=c75bb4d1194d69f5ffdad6c4c8185ef4d4cc3e896cc49aa566ef6fa0648e19fe",
         "title":"L1C_T18TWN_A028079_20201106T160014.tif"
      }
   },
   "bbox":[
      499980.0,
      4690200.0,
      609780.0,
      4800000.0
   ],
   "stac_extensions":[
      "projection"
   ]
}
```
