### PR TITLE
Add setting to allow access to unassigned permissions for all users

### DIFF
--- a/rgd/geodata/permissions.py
+++ b/rgd/geodata/permissions.py
@@ -105,7 +105,7 @@ def filter_perm(user, queryset, role):
     filtered = queryset.filter(**{user_path: user.pk}).exclude(**{role_path + '__lt': role})
     # Check setting for unassigned permissions
     if settings.RGD_GLOBAL_READ_ACCESS:
-        unassigned = queryset.filter(**{'_collection_permissions__user': None})
+        unassigned = queryset.filter(**{user_path: None})
         return unassigned.union(filtered)  # This union throws an error
     return filtered
 

--- a/rgd/geodata/permissions.py
+++ b/rgd/geodata/permissions.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.conf import settings
 from django.contrib.auth.backends import BaseBackend
 from django.core.exceptions import PermissionDenied
 from django.db.models.functions import Coalesce
@@ -86,22 +87,27 @@ def filter_perm(user, queryset, role):
     # Called outside of view
     if user is None:
         return queryset
-    # Admins can see all
-    if user.is_active and (user.is_staff or user.is_superuser):
+    # Must be logged in
+    if not user.is_active or user.is_anonymous:
+        return queryset.none()
+    # Superusers can see all (not staff users)
+    if user.is_active and user.is_superuser:
         return queryset
     # No relationship to collection
     path = get_collection_membership_path(queryset.model)
     if path is None:
         return queryset
-    # Must be logged in
-    if not user.is_active or user.is_anonymous:
-        return queryset.none()
     # Check permissions
     # `path` can be an empty string (meaning queryset is `CollectionPermission`)
     user_path = (path + '__' if path != '' else path) + 'user'
     role_path = (path + '__' if path != '' else path) + 'role'
     queryset = annotate_queryset(queryset)
-    return queryset.filter(**{user_path: user.pk}).exclude(**{role_path + '__lt': role})
+    filtered = queryset.filter(**{user_path: user.pk}).exclude(**{role_path + '__lt': role})
+    # Check setting for unassigned permissions
+    if settings.RGD_GLOBAL_READ_ACCESS:
+        unassigned = queryset.filter(**{'_collection_permissions__user': None})
+        return unassigned.union(filtered)  # This union throws an error
+    return filtered
 
 
 def filter_read_perm(user, queryset):

--- a/rgd/geodata/permissions.py
+++ b/rgd/geodata/permissions.py
@@ -105,7 +105,7 @@ def filter_perm(user, queryset, role):
     filtered = queryset.filter(**{user_path: user.pk}).exclude(**{role_path + '__lt': role})
     # Check setting for unassigned permissions
     if settings.RGD_GLOBAL_READ_ACCESS:
-        unassigned = queryset.filter(**{user_path: None})
+        unassigned = queryset.filter(**{user_path + '__isnull': True})
         return unassigned.union(filtered)  # This union throws an error
     return filtered
 

--- a/rgd/geodata/permissions.py
+++ b/rgd/geodata/permissions.py
@@ -111,7 +111,7 @@ def filter_perm(user, queryset, role):
 
 
 def filter_read_perm(user, queryset):
-    """Filter a queryset to what the user may edit."""
+    """Filter a queryset to what the user may read."""
     return filter_perm(user, queryset, models.CollectionPermission.READER)
 
 

--- a/rgd/geodata/permissions.py
+++ b/rgd/geodata/permissions.py
@@ -106,7 +106,7 @@ def filter_perm(user, queryset, role):
     # Check setting for unassigned permissions
     if settings.RGD_GLOBAL_READ_ACCESS:
         unassigned = queryset.filter(**{user_path + '__isnull': True})
-        return unassigned.union(filtered)  # This union throws an error
+        return unassigned | filtered
     return filtered
 
 

--- a/rgd/settings.py
+++ b/rgd/settings.py
@@ -15,7 +15,7 @@ from configurations import values
 
 class GeoDjangoMixin(ConfigMixin):
     # A setting to allow read access to all users if permissions are unassigned
-    RGD_GLOBAL_READ_ACCESS = values.Value(default=True)
+    RGD_GLOBAL_READ_ACCESS = values.Value(default=False)
 
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):

--- a/rgd/settings.py
+++ b/rgd/settings.py
@@ -14,6 +14,9 @@ from configurations import values
 
 
 class GeoDjangoMixin(ConfigMixin):
+    # A setting to allow read access to all users if permissions are unassigned
+    RGD_GLOBAL_READ_ACCESS = values.Value(default=True)
+
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
         configuration.INSTALLED_APPS += ['django.contrib.gis']


### PR DESCRIPTION
Adds a new setting to give global read access to records that do not have assigned permissions. 

This is useful if we want all users to have access to all data in an instance by default and still be able to make certain collections private.