### PR TITLE
Set large_image version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'djangorestframework',
         'drf-yasg',
         'GDAL',
-        'large-image>=1.4.3',
+        'large-image>=1.6.0',
         'large-image-source-gdal',
         'numpy',
         'pooch',

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'djangorestframework',
         'drf-yasg',
         'GDAL',
+        'large-image>=1.4.3',
         'large-image-source-gdal',
         'numpy',
         'pooch',


### PR DESCRIPTION
Follow up to https://github.com/ResonantGeoData/ResonantGeoData/issues/307#issuecomment-797640849

We are seeing #307 again on the Heroku instance lately. Hopefully setting the min version will prevent an older large_image from being installed