### PR TITLE
Add Terraform to store watch_dev state

### DIFF
--- a/terraform/watch.tf
+++ b/terraform/watch.tf
@@ -18,12 +18,12 @@ module "watch_smtp" {
   source  = "girder/girder/aws//modules/smtp"
   version = "0.8.0"
 
-  fqdn = aws_route53_record.watch.fqdn
-  project_slug = "watch"
+  fqdn            = aws_route53_record.watch.fqdn
+  project_slug    = "watch"
   route53_zone_id = aws_route53_zone.common.zone_id
 }
 
 output "watch_smtp_url" {
-  value = "submission://${urlencode(module.watch_smtp.username)}:${urlencode(module.watch_smtp.password)}@${module.watch_smtp.host}:${module.watch_smtp.port}"
+  value     = "submission://${urlencode(module.watch_smtp.username)}:${urlencode(module.watch_smtp.password)}@${module.watch_smtp.host}:${module.watch_smtp.port}"
   sensitive = true
 }

--- a/terraform/watch_dev.tf
+++ b/terraform/watch_dev.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  alias               = "aws_ohio"
+  region              = "us-east-2"
+  allowed_account_ids = ["381864640041"]
+  # Must set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY envvars
+}
+
+# Provisioned manually
+data "aws_instance" "watch_dev" {
+  provider = aws.aws_ohio
+
+  filter {
+    name   = "tag:Name"
+    values = ["abhishek-rgd"]
+  }
+}
+
+resource "aws_eip" "watch_dev" {
+  provider = aws.aws_ohio
+
+  instance = data.aws_instance.watch_dev.instance_id
+  tags = {
+    Name = "abhishek-rgd"
+  }
+}
+
+resource "aws_route53_record" "watch_dev" {
+  provider = aws.aws_ohio
+
+  name    = "watch-test"
+  type    = "A"
+  zone_id = aws_route53_zone.common.zone_id
+  records = [aws_eip.watch_dev.public_ip]
+}


### PR DESCRIPTION
These resources were created manually, but have been imported into the TF state to ensure they get cleaned up.