### PR TITLE
Add a missing TTL for aws_eip.watch_dev TF

### DIFF
--- a/terraform/watch_dev.tf
+++ b/terraform/watch_dev.tf
@@ -29,6 +29,7 @@ resource "aws_route53_record" "watch_dev" {
 
   name    = "watch-test"
   type    = "A"
+  ttl     = "300"
   zone_id = aws_route53_zone.common.zone_id
   records = [aws_eip.watch_dev.public_ip]
 }


### PR DESCRIPTION
This bug wasn't detected by the TF plan.