### PR TITLE
Local tox development environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,8 +36,9 @@ but allows developers to run Python code on their native system.
 2. Install Python 3.8
 3. Install
    [`psycopg2` build prerequisites](https://www.psycopg.org/docs/install.html#build-prerequisites)
-4. Create and activate a new Python virtualenv
-5. Run: `pip install --find-links https://girder.github.io/large_image_wheels -e .[dev,worker]`
+4. Create a new Python virtualenv: `tox --devenv .venv -e dev`. Force recreation
+   introducing updated dependencies: `tox -r --devenv .venv -e dev`
+5. Activate it as usual: `source ./.venv/bin/activate`
 6. Run `source ./dev/export-env.sh`
 7. Run `./manage.py migrate`
 8. Run `./manage.py createsuperuser` and follow the prompts to create your own user

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,17 @@ commands =
     coverage html -d {toxworkdir}/htmlcov/django-rgd-imagery
     coverage xml -o {toxworkdir}/coverage.xml
 
+[testenv:dev]
+deps =
+    {[testenv:lint]deps}
+    {[testenv:type]deps}
+    {[testenv:format]deps}
+    {[testenv:test-rgd]deps}
+    {[testenv:test-rgd-3d]deps}
+    {[testenv:test-rgd-fmv]deps}
+    {[testenv:test-rgd-geometry]deps}
+    {[testenv:test-rgd-imagery]deps}
+
 [flake8]
 max-line-length = 2048
 show-source = True

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,7 @@ exclude =
     .tox
     __pycache__
     */*egg*/*
+    .venv
 ignore =
     # closing bracket does not match indentation of opening bracket’s line
     E123


### PR DESCRIPTION
I find it useful to have all the dependencies installed locally so I can use editor magic to follow imported symbols. Tox has a pleasant way to instantiate a development environment [documented here](https://tox.readthedocs.io/en/latest/example/devenv.html).

This PR adds a tox "testenv" that has all dependencies and documents how to use this to create a development venv.