### PR TITLE
Fix SATC serializer create

### DIFF
--- a/django-rgd-imagery/rgd_imagery/serializers.py
+++ b/django-rgd-imagery/rgd_imagery/serializers.py
@@ -224,8 +224,9 @@ class STACRasterSerializer(serializers.BaseSerializer):
         raster, _ = get_or_create_no_commit(
             models.Raster, image_set=image_set, defaults=dict(name=item.id)
         )
-        [raster.ancillary_files.add(af) for af in ancillary]
         raster.skip_signal = True
+        raster.save()
+        [raster.ancillary_files.add(af) for af in ancillary]
         raster.save()
 
         outline = Polygon(

--- a/django-rgd-imagery/rgd_imagery/serializers.py
+++ b/django-rgd-imagery/rgd_imagery/serializers.py
@@ -11,6 +11,7 @@ from rgd import utility
 from rgd.models import ChecksumFile, FileSourceType
 from rgd.permissions import check_write_perm
 from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
+from rgd.utility import get_or_create_no_commit
 
 from . import models
 
@@ -218,11 +219,13 @@ class STACRasterSerializer(serializers.BaseSerializer):
 
         image_set = models.ImageSet.objects.create()
         image_set.images.set(images)
+        image_set.save()
 
-        raster, _ = models.Raster.objects.get_or_create(
-            image_set=image_set, defaults=dict(name=item.id)
+        raster, _ = get_or_create_no_commit(
+            models.Raster, image_set=image_set, defaults=dict(name=item.id)
         )
         [raster.ancillary_files.add(af) for af in ancillary]
+        raster.skip_signal = True
         raster.save()
 
         outline = Polygon(


### PR DESCRIPTION
The STAC serializer's create method should not trigger the raster ETL routines.

Currently we're ingesting NITF images that those ETL routines do not support so this is necessary