### PR TITLE
Catch libfuse missing

### DIFF
--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -191,7 +191,7 @@ def url_file_to_local_path(url: str, num_blocks=128, block_size=128) -> Generato
 def precheck_fuse(url: str) -> bool:
     try:
         import simple_httpfs  # noqa
-    except ImportError:
+    except (ImportError, EnvironmentError):
         return False
     parsed = urlparse(url)
     if parsed.scheme not in ['https', 'http']:


### PR DESCRIPTION
Catches an issue when `simple_httpfs` is installed but `libfuse` is missing