### PR TITLE
Permissions path

### DIFF
--- a/django-rgd-3d/rgd_3d/models/point_cloud.py
+++ b/django-rgd-3d/rgd_3d/models/point_cloud.py
@@ -17,7 +17,7 @@ class PointCloud(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     data_link.allow_tags = True
 
-    permissions_paths = ['file__collection__collection_permissions']
+    permissions_paths = ['file']
 
 
 class PointCloudMeta(TimeStampedModel, PermissionPathMixin, DetailViewMixin):
@@ -42,8 +42,8 @@ class PointCloudMeta(TimeStampedModel, PermissionPathMixin, DetailViewMixin):
     data_link.allow_tags = True
 
     permissions_paths = [
-        'source__file__collection__collection_permissions',
-        'vtp_data__collection__collection_permissions',
+        'source__file',
+        'vtp_data',
     ]
     detail_view_name = 'point-cloud-entry-detail'
 
@@ -62,5 +62,5 @@ class PointCloudSpatial(TimeStampedModel, SpatialEntry, PermissionPathMixin):
         return self.source.file.name
 
     permissions_paths = [
-        'source__file__collection__collection_permissions',
+        'source__file',
     ]

--- a/django-rgd-3d/tests/test_permissions.py
+++ b/django-rgd-3d/tests/test_permissions.py
@@ -1,0 +1,7 @@
+from django.apps import apps
+from rgd_testing_utils.helpers import check_model_permissions
+
+
+def test_check_permissions_path_rgd_3d():
+    for model in apps.get_app_config('rgd_3d').get_models():
+        check_model_permissions(model)

--- a/django-rgd-fmv/rgd_fmv/models/base.py
+++ b/django-rgd-fmv/rgd_fmv/models/base.py
@@ -32,7 +32,7 @@ class FMV(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     klv_data_link.allow_tags = True
 
-    permissions_paths = ['file__collection__collection_permissions']
+    permissions_paths = ['file']
 
 
 class FMVMeta(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMixin):
@@ -53,7 +53,7 @@ class FMVMeta(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMix
     def _blob_to_array(blob):
         return pickle.loads(base64.b64decode(blob))
 
-    permissions_paths = ['fmv_file__file__collection__collection_permissions']
+    permissions_paths = ['fmv_file__file']
     detail_view_name = 'fmv-entry-detail'
 
     @property

--- a/django-rgd-fmv/tests/test_permissions.py
+++ b/django-rgd-fmv/tests/test_permissions.py
@@ -1,0 +1,7 @@
+from django.apps import apps
+from rgd_testing_utils.helpers import check_model_permissions
+
+
+def test_check_permissions_path_rgd_fmv():
+    for model in apps.get_app_config('rgd_fmv').get_models():
+        check_model_permissions(model)

--- a/django-rgd-geometry/rgd_geometry/models/base.py
+++ b/django-rgd-geometry/rgd_geometry/models/base.py
@@ -36,7 +36,7 @@ class GeometryArchive(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     archive_data_link.allow_tags = True
 
-    permissions_paths = ['file__collection__collection_permissions']
+    permissions_paths = ['file']
 
 
 class Geometry(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMixin):
@@ -51,5 +51,5 @@ class Geometry(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMi
     # Can be null if not generated from uploaded ZIP file but something else
     geometry_archive = models.OneToOneField(GeometryArchive, null=True, on_delete=models.CASCADE)
 
-    permissions_paths = ['geometry_archive__file__collection__collection_permissions']
+    permissions_paths = ['geometry_archive__file']
     detail_view_name = 'geometry-entry-detail'

--- a/django-rgd-geometry/tests/test_permissions.py
+++ b/django-rgd-geometry/tests/test_permissions.py
@@ -1,0 +1,7 @@
+from django.apps import apps
+from rgd_testing_utils.helpers import check_model_permissions
+
+
+def test_check_permissions_path_rgd_geometry():
+    for model in apps.get_app_config('rgd_geometry').get_models():
+        check_model_permissions(model)

--- a/django-rgd-imagery/rgd_imagery/models/annotation.py
+++ b/django-rgd-imagery/rgd_imagery/models/annotation.py
@@ -27,7 +27,7 @@ class Annotation(TimeStampedModel, PermissionPathMixin):
         """Get type of segmentation."""
         return self.segmentation.get_type()
 
-    permissions_paths = ['image__collection__collection_permissions']
+    permissions_paths = ['image__file']
 
 
 class Segmentation(models.Model):
@@ -67,7 +67,7 @@ class Segmentation(models.Model):
             pass
         return 'Oultine/BBox'
 
-    permissions_paths = ['annotation__image__collection__collection_permissions']
+    permissions_paths = ['annotation__image__file']
 
 
 class PolygonSegmentation(Segmentation):

--- a/django-rgd-imagery/rgd_imagery/models/base.py
+++ b/django-rgd-imagery/rgd_imagery/models/base.py
@@ -17,7 +17,7 @@ class Image(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     """
 
-    permissions_paths = ['file__collection__collection_permissions']
+    permissions_paths = ['file']
     task_funcs = (jobs.task_load_image,)
     file = models.ForeignKey(ChecksumFile, on_delete=models.CASCADE, related_name='+')
 
@@ -30,7 +30,7 @@ class Image(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 class ImageMeta(TimeStampedModel, PermissionPathMixin):
     """Single image entry, tracks the original file."""
 
-    permissions_paths = ['parent_image__file__collection__collection_permissions']
+    permissions_paths = ['parent_image__file']
 
     parent_image = models.OneToOneField(Image, on_delete=models.CASCADE)
     driver = models.CharField(max_length=100)
@@ -42,7 +42,7 @@ class ImageMeta(TimeStampedModel, PermissionPathMixin):
 class BandMeta(TimeStampedModel, PermissionPathMixin):
     """A basic container to keep track of useful band info."""
 
-    permissions_paths = ['parent_image__file__collection__collection_permissions']
+    permissions_paths = ['parent_image__file']
     parent_image = models.ForeignKey(Image, on_delete=models.CASCADE)
     band_number = models.IntegerField()
     description = models.TextField(
@@ -62,7 +62,7 @@ class BandMeta(TimeStampedModel, PermissionPathMixin):
 class ImageSet(TimeStampedModel, PermissionPathMixin):
     """Container for many images."""
 
-    permissions_paths = ['images__file__collection__collection_permissions']
+    permissions_paths = ['images__file']
 
     name = models.CharField(max_length=1000, blank=True)
     description = models.TextField(null=True, blank=True)
@@ -95,7 +95,7 @@ class ImageSet(TimeStampedModel, PermissionPathMixin):
 class ImageSetSpatial(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMixin):
     """Arbitrary register an ImageSet to a location."""
 
-    permissions_paths = ['image_set__images__file__collection__collection_permissions']
+    permissions_paths = ['image_set__images__file']
     detail_view_name = 'image-set-spatial-detail'
 
     image_set = models.OneToOneField(ImageSet, on_delete=models.CASCADE)

--- a/django-rgd-imagery/rgd_imagery/models/kwcoco.py
+++ b/django-rgd-imagery/rgd_imagery/models/kwcoco.py
@@ -46,6 +46,6 @@ class KWCOCOArchive(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
         self.image_set.delete()
 
     permissions_paths = [
-        'spec_file__collection__collection_permissions',
-        'image_archive__collection__collection_permissions',
+        'spec_file',
+        'image_archive',
     ]

--- a/django-rgd-imagery/rgd_imagery/models/processed.py
+++ b/django-rgd-imagery/rgd_imagery/models/processed.py
@@ -26,7 +26,7 @@ class ProcessedImage(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
         if self.processed_image:
             self.processed_image.file.delete()
 
-    permissions_paths = ['source_image__file__collection__collection_permissions']
+    permissions_paths = ['source_image__file']
 
 
 class ConvertedImage(ProcessedImage):

--- a/django-rgd-imagery/rgd_imagery/models/raster.py
+++ b/django-rgd-imagery/rgd_imagery/models/raster.py
@@ -18,7 +18,7 @@ class Raster(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     """
 
-    permissions_paths = ['image_set__images__file__collection__collection_permissions']
+    permissions_paths = ['image_set__images__file']
 
     name = models.CharField(max_length=1000, blank=True)
     description = models.TextField(null=True, blank=True)
@@ -44,9 +44,7 @@ class Raster(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
 
 class RasterMeta(TimeStampedModel, SpatialEntry, PermissionPathMixin, DetailViewMixin):
-    permissions_paths = [
-        'parent_raster__image_set__images__file__collection__collection_permissions'
-    ]
+    permissions_paths = ['parent_raster__image_set__images__file']
     detail_view_name = 'raster-entry-detail'
 
     parent_raster = models.OneToOneField(Raster, on_delete=models.CASCADE)

--- a/django-rgd-imagery/tests/test_permissions.py
+++ b/django-rgd-imagery/tests/test_permissions.py
@@ -1,0 +1,7 @@
+from django.apps import apps
+from rgd_testing_utils.helpers import check_model_permissions
+
+
+def test_check_permissions_path_rgd_imagery():
+    for model in apps.get_app_config('rgd_imagery').get_models():
+        check_model_permissions(model)

--- a/django-rgd/rgd/models/collection.py
+++ b/django-rgd/rgd/models/collection.py
@@ -5,7 +5,7 @@ from .mixins import PermissionPathMixin
 
 
 class Collection(models.Model, PermissionPathMixin):
-    permissions_paths = ['collection_permissions']
+    permissions_paths = []
 
     name = models.CharField(max_length=127)
 
@@ -16,14 +16,14 @@ class Collection(models.Model, PermissionPathMixin):
         default_related_name = 'collections'
 
 
-class CollectionPermission(models.Model):
+class CollectionPermission(models.Model, PermissionPathMixin):
     READER = 1
     OWNER = 2
     ROLE_CHOICES = [
         (READER, 'Reader'),
         (OWNER, 'Owner'),
     ]
-    permissions_paths = ['']
+    permissions_paths = []
 
     collection = models.ForeignKey(Collection, on_delete=models.CASCADE)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/django-rgd/rgd/models/common.py
+++ b/django-rgd/rgd/models/common.py
@@ -100,7 +100,7 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
     task_funcs = (
         # tasks.task_checksum_file_post_save,
     )
-    permissions_paths = ['collection__collection_permissions']
+    permissions_paths = ['']
 
     class Meta:
         constraints = [
@@ -303,6 +303,6 @@ class SpatialAsset(SpatialEntry, TimeStampedModel, PermissionPathMixin):
 
     """
 
-    permissions_paths = ['files__collection__collection_permissions']
+    permissions_paths = ['files']
 
     files = models.ManyToManyField(ChecksumFile)

--- a/django-rgd/tests/test_permissions.py
+++ b/django-rgd/tests/test_permissions.py
@@ -1,7 +1,9 @@
+from django.apps import apps
 from django.conf import settings
 import pytest
 from rgd import models
 from rgd.permissions import filter_read_perm
+from rgd_testing_utils.helpers import check_model_permissions
 
 
 @pytest.mark.django_db(transaction=True)
@@ -20,3 +22,8 @@ def test_unassigned_permissions_complex(user_factory, user, spatial_asset_a, spa
     assert len(admin_q) == len(basic_q)
     assert set(admin_q) == set(basic_q)
     settings.RGD_GLOBAL_READ_ACCESS = prior
+
+
+def test_check_permissions_path_rgd():
+    for model in apps.get_app_config('rgd').get_models():
+        check_model_permissions(model)

--- a/testing-utils/rgd_testing_utils/helpers.py
+++ b/testing-utils/rgd_testing_utils/helpers.py
@@ -1,0 +1,45 @@
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import ForeignKey, ManyToManyField, OneToOneField
+import pytest
+from rgd import models
+from rgd.permissions import get_collection_permissions_paths
+
+
+def check_model_permissions(model):
+    if not issubclass(model, models.mixins.PermissionPathMixin):
+        return
+
+    try:
+        permissions_paths = get_collection_permissions_paths(model)
+        assert permissions_paths  # field exists and non-empty
+    except TypeError:
+        pytest.fail('permissions_paths does not exist on model')
+
+    # iterate paths
+    for path in permissions_paths:
+        fields = path.split('__')
+        current_model = model
+
+        # iterate fields which span relations
+        for f in fields:
+
+            # reached end of lookup path
+            if f == '':
+                return
+
+            # check that relation exists on current model
+            try:
+                if (
+                    isinstance(current_model, ForeignKey)
+                    or isinstance(current_model, ManyToManyField)
+                    or isinstance(current_model, OneToOneField)
+                ):
+                    current_model = current_model.related_model
+
+                current_model = current_model._meta.get_field(f)
+            except FieldDoesNotExist:
+                pytest.fail(
+                    'Path error: field {} does not exist on model {}'.format(
+                        f, current_model.__str__
+                    )
+                )


### PR DESCRIPTION
#441 

- Add testing for existence and correctness of `permissions_path` field (i.e on models that extend `PermissionPathMixin`): Iterates over models and traces path via class definitions
- Refactored `permissions_path` to not repeat `__collection__collection_permissions` everywhere: simply prepend to existing path. 

Point 2 could still be improved: One idea is to only explicitly have the next model in the path in the `permissions_path` field and dynamically build the rest. For example, the current path for class `FMVMeta` is [`fmv_file__file__collection__collection_permissions`], but instead we could change it to simply [`fmv_file` + <path for `class FMV`>] and then in class `FMV`, replace the path with [`file` + <path for `class File`>], etc.