### PR TITLE
Fix typos and add codespell to tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 2D/3D/4D Geospatial Data API in Django
 
-A publically deployed instance of this application is available at https://www.resonantgeodata.com - find the project code for this at [ResonantGeoData/RD-OpenGeo](https://github.com/ResonantGeoData/RD-OpenGeo)
+A publicly deployed instance of this application is available at https://www.resonantgeodata.com - find the project code for this at [ResonantGeoData/RD-OpenGeo](https://github.com/ResonantGeoData/RD-OpenGeo)
 
 ResonantGeoData is a Django application well suited for catalogging and searching annotated geospatial imagery, shapefiles, and full motion video datasets.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A publicly deployed instance of this application is available at https://www.resonantgeodata.com - find the project code for this at [ResonantGeoData/RD-OpenGeo](https://github.com/ResonantGeoData/RD-OpenGeo)
 
-ResonantGeoData is a Django application well suited for catalogging and searching annotated geospatial imagery, shapefiles, and full motion video datasets.
+ResonantGeoData is a Django application well suited for cataloging and searching annotated geospatial imagery, shapefiles, and full motion video datasets.
 
 ![homepage](./docs/images/homepage.png)
 

--- a/django-rgd-3d/vtkjs_viewer/src/index.js
+++ b/django-rgd-3d/vtkjs_viewer/src/index.js
@@ -193,7 +193,7 @@ function createPipeline (fileContents, name = undefined) {
   pointSizeSelector.setAttribute('value', '1');
   pointSizeSelector.setAttribute('max', '20');
   pointSizeSelector.setAttribute('min', '1');
-  pointSizeSelector.style.display = 'none'; // Deafault hidden
+  pointSizeSelector.style.display = 'none'; // Default hidden
 
   if (name === undefined) {
     name = 'Mesh';

--- a/django-rgd-fmv/rgd_fmv/tasks/etl.py
+++ b/django-rgd-fmv/rgd_fmv/tasks/etl.py
@@ -115,7 +115,7 @@ def _get_path_and_footprints(content):
         p = Polygon(box, srid=srid)
         polys.append(p)
         if union is None:
-            # Ony on first
+            # Only on first
             union = p
         else:
             union = union.union(p)
@@ -206,7 +206,7 @@ def read_fmv_file(fmv_file_id):
     fmv_file.skip_signal = True
 
     validation = True  # TODO: use `fmv_file.file.validate()`
-    # Only extraxt the KLV data if it does not exist or the checksum of the video has changed
+    # Only extract the KLV data if it does not exist or the checksum of the video has changed
     if not fmv_file.klv_file or not validation:
         _extract_klv(fmv_file)
     if not fmv_file.web_video_file or not validation:

--- a/django-rgd-imagery/rgd_imagery/migrations/0001_initial.py
+++ b/django-rgd-imagery/rgd_imagery/migrations/0001_initial.py
@@ -645,7 +645,7 @@ class Migration(migrations.Migration):
                     'description',
                     models.TextField(
                         blank=True,
-                        help_text='Automatically retreived from raster but can be overwritten.',
+                        help_text='Automatically retrieved from raster but can be overwritten.',
                         null=True,
                     ),
                 ),

--- a/django-rgd-imagery/rgd_imagery/models/__init__.py
+++ b/django-rgd-imagery/rgd_imagery/models/__init__.py
@@ -1,4 +1,4 @@
-"""This models contains a model heirarchy for raster datasets.
+"""This models contains a model hierarchy for raster datasets.
 
 The ``base`` module contains base classes for representing raster models.
 As new data types are introduced to the database, a new model for that data

--- a/django-rgd-imagery/rgd_imagery/models/annotation.py
+++ b/django-rgd-imagery/rgd_imagery/models/annotation.py
@@ -76,7 +76,7 @@ class PolygonSegmentation(Segmentation):
     Note
     ----
     We use ``MultiPolygonField`` as the segmentation can be multiple
-    seperated polygons across the image.
+    separated polygons across the image.
 
     """
 

--- a/django-rgd-imagery/rgd_imagery/models/base.py
+++ b/django-rgd-imagery/rgd_imagery/models/base.py
@@ -48,7 +48,7 @@ class BandMeta(TimeStampedModel, PermissionPathMixin):
     description = models.TextField(
         null=True,
         blank=True,
-        help_text='Automatically retreived from raster but can be overwritten.',
+        help_text='Automatically retrieved from raster but can be overwritten.',
     )
     dtype = models.CharField(max_length=10)
     max = models.FloatField(null=True)

--- a/django-rgd-imagery/rgd_imagery/models/kwcoco.py
+++ b/django-rgd-imagery/rgd_imagery/models/kwcoco.py
@@ -36,7 +36,7 @@ class KWCOCOArchive(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
     image_set = models.OneToOneField(ImageSet, on_delete=models.SET_NULL, null=True)
 
     def _post_delete(self, *args, **kwargs):
-        # Frist delete all the images in the image set
+        # First delete all the images in the image set
         #  this will cascade to the annotations
         images = self.image_set.images.all()
         for image in images:

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -107,7 +107,7 @@ class TileRegionView(BaseTileView):
 
 
 class TileRegionPixelView(BaseTileView):
-    """Returns region tile binary from pixel coordiantes."""
+    """Returns region tile binary from pixel coordinates."""
 
     def get(
         self, request: Request, pk: int, left: float, right: float, bottom: float, top: float

--- a/django-rgd-imagery/rgd_imagery/tasks/etl.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/etl.py
@@ -38,7 +38,7 @@ def _populate_image_meta_models(image_meta, image_file_path):
         image_meta.height = src.shape[0]
         image_meta.width = src.shape[1]
 
-        # A catch-all metadata feild:
+        # A catch-all metadata field:
         # TODO: image_meta.metadata =
 
         # These are things I couldn't figure out how to get with gdal directly
@@ -58,7 +58,7 @@ def _populate_image_meta_models(image_meta, image_file_path):
                 band_meta.dtype = dtypes[i]
             except IndexError:
                 pass
-            # TODO: seperate out band stats into separate tasks
+            # TODO: separate out band stats into separate tasks
             # bmin, bmax, mean, std = gdal_band.GetStatistics(True, True)
             # band_meta.min = bmin
             # band_meta.max = bmax

--- a/django-rgd/rgd/models/common.py
+++ b/django-rgd/rgd/models/common.py
@@ -70,7 +70,7 @@ class FileSourceType(models.IntegerChoices):
 class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
     """The main class for user-uploaded files.
 
-    This has support for manually uploading files or specifing a URL to a file
+    This has support for manually uploading files or specifying a URL to a file
     (for example in an existing S3 bucket). This broadly supports ``http<s>://``
     URLs to file resources as well as ``s3://`` as long as the node the app is
     running on is provisioned to access that S3 bucket.
@@ -297,7 +297,7 @@ class SpatialAsset(SpatialEntry, TimeStampedModel, PermissionPathMixin):
     """Any spatially referenced file set.
 
     This can be any collection of files that have a spatial reference and are
-    not explictly handled by the other SpatialEntry subtypes. For example, this
+    not explicitly handled by the other SpatialEntry subtypes. For example, this
     model can be used to hold a collection of PDF documents or slide decks that
     have a georeference.
 

--- a/django-rgd/rgd/templates/rgd/_include/search_map.html
+++ b/django-rgd/rgd/templates/rgd/_include/search_map.html
@@ -9,7 +9,7 @@
       let searchGeometry = JSON.parse(searchParams.q)
       // Add search parameters as markers
       if (searchGeometry.type == 'Point') {
-        // center map here by default (incase no data appears in search)
+        // center map here by default (in case no data appears in search)
         map.center({
            x: searchGeometry.coordinates[0],
            y: searchGeometry.coordinates[1]

--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -264,9 +264,9 @@ def output_path_helper(filename: str, output: FieldFile):
 def input_output_path_helper(
     source, output: FieldFile, prefix: str = '', suffix: str = '', vsi: bool = False
 ):
-    """Yeild source and output paths between a ChecksumFile and a FileFeild.
+    """Yield source and output paths between a ChecksumFile and a FileFeild.
 
-    The output path is saved to the output field after yeilding.
+    The output path is saved to the output field after yielding.
 
     """
     filename = prefix + os.path.basename(source.name) + suffix

--- a/django-rgd/tests/test_common.py
+++ b/django-rgd/tests/test_common.py
@@ -96,7 +96,7 @@ def test_checksumfile_file_yield_local_path(file_path):
     path = model.yield_local_path()
     with model.yield_local_path() as path:
         assert os.path.exists(path)
-    # Make sure it is cleaned up afer context ends
+    # Make sure it is cleaned up after context ends
     assert not os.path.exists(path)
     # Now test that is gets cleaned up during an exception
     with pytest.raises(ValueError):
@@ -113,7 +113,7 @@ def test_checksumfile_url_yield_local_path():
     model.save()
     with model.yield_local_path() as path:
         assert os.path.exists(path)
-    # Make sure it is cleaned up afer context ends
+    # Make sure it is cleaned up after context ends
     assert not os.path.exists(path)
     # Now test that is gets cleaned up during an exception
     with pytest.raises(ValueError):

--- a/docs/ingest-data.md
+++ b/docs/ingest-data.md
@@ -14,7 +14,7 @@ Then simply create a new `ImageFile` entry that links to the previously created 
 
 ![image_file](./images/image_file.png)
 
-This step lets the data catalog know that the added file is an image, and it will begin a few processing routines in the background to create an `ImageEntry` automatically. Once saved, you can go to the "image entrys" section of the admin portal, and you will find your image listed there:
+This step lets the data catalog know that the added file is an image, and it will begin a few processing routines in the background to create an `ImageEntry` automatically. Once saved, you can go to the image entries section of the admin portal, and you will find your image listed there:
 
 ![image_entry_list](./images/image_entry_list.png)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     lint,
+    codespell,
     check-migrations,
     test-rgd,
     test-rgd-3d,
@@ -33,6 +34,14 @@ deps =
     pep8-naming
 commands =
     flake8 {posargs:.}
+
+[testenv:codespell]
+deps =
+    codespell
+commands =
+    codespell \
+      -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.js,*.pickle,*.ipynb,*node_modules,./.tox,./.git,*.egg-info" \
+      {posargs}
 
 [testenv:type]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     codespell
 commands =
     codespell \
-      -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.js,*.pickle,*.ipynb,*node_modules,./.tox,./.git,*.egg-info" \
+      -S "*.pyc,*.txt,*.gif,*.png,*.jpg,*.pickle,*.ipynb,*node_modules,*static,./.tox,./.git,*.egg-info" \
       {posargs}
 
 [testenv:type]


### PR DESCRIPTION
This fixes a handful of spelling errors and implements [codespell](https://github.com/codespell-project/codespell/) in a new tox test

I did not add this to the CI tests because codespell can get quite annoying if left on its own. This is useful as a local check to find and correct spelling errors.

simply run `tox -e codespell` to check for spelling errors