### PR TITLE
Support individual band selection in raster detail view

### DIFF
--- a/django-rgd-imagery/rgd_imagery/large_image_utilities.py
+++ b/django-rgd-imagery/rgd_imagery/large_image_utilities.py
@@ -5,14 +5,16 @@ from large_image_source_pil import PILFileTileSource
 from rgd_imagery.models import Image
 
 
-def get_tilesource_from_image(image: Image, projection: str = None) -> FileTileSource:
+def get_tilesource_from_image(
+    image: Image, projection: str = None, style: str = None
+) -> FileTileSource:
     # Make sure projection is None by default to use source projection
     try:
         file_path = image.file.get_vsi_path(internal=True)
-        return GDALFileTileSource(file_path, projection=projection, encoding='PNG')
+        return GDALFileTileSource(file_path, projection=projection, encoding='PNG', style=style)
     except TileSourceException:
         with image.file.yield_local_path() as file_path:
-            return PILFileTileSource(file_path)
+            return PILFileTileSource(file_path, style=style)
 
 
 def get_region_world(

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -17,7 +17,7 @@ class BaseTileView(APIView):
         image_entry = get_object_or_404(Image, pk=pk)
         self.check_object_permissions(request, image_entry)
         projection = request.query_params.get('projection', None)
-        band = int(request.query_params.get('band', None))
+        band = int(request.query_params.get('band', 0))
         if band:
             style = json.dumps({'band': band})
         return large_image_utilities.get_tilesource_from_image(image_entry, projection, style=style)

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -1,3 +1,5 @@
+import json
+
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from large_image.tilesource import FileTileSource
@@ -10,12 +12,15 @@ from rgd_imagery.models import Image
 
 
 class BaseTileView(APIView):
-    def get_tile_source(self, request: Request, pk: int) -> FileTileSource:
+    def get_tile_source(self, request: Request, pk: int, style: str = None) -> FileTileSource:
         """Return the built tile source."""
         image_entry = get_object_or_404(Image, pk=pk)
         self.check_object_permissions(request, image_entry)
         projection = request.query_params.get('projection', None)
-        return large_image_utilities.get_tilesource_from_image(image_entry, projection)
+        band = int(request.query_params.get('band', None))
+        if band:
+            style = json.dumps({'band': band})
+        return large_image_utilities.get_tilesource_from_image(image_entry, projection, style=style)
 
 
 class TileMetadataView(BaseTileView):

--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
@@ -45,7 +45,10 @@
 
   <select id="band-selector" onchange="updateBandThumbnail()">
     {% for image in object.parent_raster.image_set.images.all %}
-      <option value="{{ image.id }}">{{ image.file.name | truncatechars:36 }}</option>
+      <option value="{{ image.id }}.0">{{ image.file.name | truncatechars:36 }}-Default</option>
+      {% for bmeta in image.bandmeta_set.all %}
+        <option value="{{ image.id }}.{{bmeta.band_number}}">{{ image.file.name | truncatechars:36 }}-{{bmeta.band_number}} ({{bmeta.interpretation}}: {{bmeta.description}})</option>
+      {% endfor %}
     {% endfor %}
     <option value="-1">-- none --</option>
   </select>
@@ -82,12 +85,18 @@
     function updateBandThumbnail () {
       selector = document.getElementById('band-selector')
       thumbnail = document.getElementById('thumbnail')
-      var image_id = Number(selector.value);
-      console.log(image_id)
-      if (image_id >= 0) {
+      var selector_value = Number(selector.value);
+      if (selector_value >= 0) {
+        var str = selector_value.toString();
+        var numarray = str.split('.');
+        image_id = Number(numarray[0])
+        band = Number(numarray[1])
+        if (Number.isNaN(band)) {
+          band = 0
+        }
         tileLayer.visible(true)
-        tileLayer.url(`${host}/api/image_process/imagery/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857`)
-        thumbnail.src = `${host}/api/image_process/imagery/${image_id}/thumbnail`
+        tileLayer.url(`${host}/api/image_process/imagery/${image_id}/tiles/{z}/{x}/{y}.png?projection=EPSG:3857&band=${band}`)
+        thumbnail.src = `${host}/api/image_process/imagery/${image_id}/thumbnail?band=${band}`
         thumbnail.hidden = false
       } else {
         tileLayer.visible(false)
@@ -116,7 +125,7 @@
       .draw();
     });
 
-    setBounds(extents.extent, true)
+    setBounds(extents.extent, false)
 
   </script>
 


### PR DESCRIPTION
In support of https://github.com/ResonantGeoData/ResonantGeoData/issues/480 (GRIB data files are supported by GDAL, so we can technically treat these as rasters and preview individual bands). At present, our ETL routines are not properly extracting the spatial reference of GRIB datasets, so this doesn't work. GRIB support will come in its own PR.

This is a needed feature on its own so I'd like to land this on its own and sort of moves us toward https://github.com/ResonantGeoData/ResonantGeoData/issues/421