### PR TITLE
More POST (and GET) endpoints!

### DIFF
--- a/django-rgd-imagery/rgd_imagery/rest/get.py
+++ b/django-rgd-imagery/rgd_imagery/rest/get.py
@@ -29,6 +29,12 @@ class GetImageSet(RetrieveAPIView, _PermissionMixin):
     queryset = models.ImageSet.objects.all()
 
 
+class GetImageSetSpatial(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.ImageSetSpatialSerializer
+    lookup_field = 'pk'
+    queryset = models.ImageSetSpatial.objects.all()
+
+
 class GetRasterMeta(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.RasterMetaSerializer
     lookup_field = 'pk'

--- a/django-rgd-imagery/rgd_imagery/rest/post.py
+++ b/django-rgd-imagery/rgd_imagery/rest/post.py
@@ -15,3 +15,23 @@ class CreateRegionImage(CreateAPIView):
 class CreateRasterSTAC(CreateAPIView):
     queryset = models.RasterMeta.objects.all()
     serializer_class = serializers.STACRasterSerializer
+
+
+class CreateImage(CreateAPIView):
+    queryset = models.Image.objects.all()
+    serializer_class = serializers.ImageSerializer
+
+
+class CreateImageSet(CreateAPIView):
+    queryset = models.ImageSet.objects.all()
+    serializer_class = serializers.ImageSetSerializer
+
+
+class CreateImageSetSpatial(CreateAPIView):
+    queryset = models.ImageSetSpatial.objects.all()
+    serializer_class = serializers.ImageSetSpatialSerializer
+
+
+class CreateRaster(CreateAPIView):
+    queryset = models.Raster.objects.all()
+    serializer_class = serializers.RasterSerializer

--- a/django-rgd-imagery/rgd_imagery/serializers/base.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/base.py
@@ -1,12 +1,16 @@
 from rest_framework import serializers
 from rest_framework.reverse import reverse
-from rgd.serializers import ChecksumFileSerializer
+from rgd.models import ChecksumFile
+from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
 
 from .. import models
 
 
 class ImageSerializer(serializers.ModelSerializer):
-    file = ChecksumFileSerializer()
+    file = ChecksumFileSerializer(read_only=True)
+    file_id = serializers.PrimaryKeyRelatedField(
+        queryset=ChecksumFile.objects.all(), write_only=True
+    )
 
     class Meta:
         model = models.Image
@@ -14,7 +18,9 @@ class ImageSerializer(serializers.ModelSerializer):
 
 
 class ImageMetaSerializer(serializers.ModelSerializer):
-    parent_image = ImageSerializer()
+    """This is read-only."""
+
+    parent_image = ImageSerializer(read_only=True)
 
     def to_representation(self, value):
         ret = super().to_representation(value)
@@ -42,6 +48,9 @@ class ImageMetaSerializer(serializers.ModelSerializer):
 
 class ImageSetSerializer(serializers.ModelSerializer):
     images = ImageSerializer(many=True)
+    images_ids = serializers.PrimaryKeyRelatedField(
+        queryset=models.Image.objects.all(), write_only=True, many=True
+    )
 
     class Meta:
         model = models.ImageSet
@@ -51,3 +60,10 @@ class ImageSetSerializer(serializers.ModelSerializer):
             'modified',
             'created',
         ]
+
+
+class ImageSetSpatialSerializer(SpatialEntrySerializer):
+    image_set = ImageSetSerializer(read_only=True)
+    image_set_id = serializers.PrimaryKeyRelatedField(
+        queryset=models.ImageSet.objects.all(), write_only=True
+    )

--- a/django-rgd-imagery/rgd_imagery/serializers/base.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/base.py
@@ -18,13 +18,7 @@ class ImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Image
         fields = '__all__'
-        read_only_fields = (
-            [
-                'id',
-            ]
-            + MODIFIABLE_READ_ONLY_FIELDS
-            + TASK_EVENT_READ_ONLY_FIELDS
-        )
+        read_only_fields = MODIFIABLE_READ_ONLY_FIELDS + TASK_EVENT_READ_ONLY_FIELDS
 
 
 class ImageMetaSerializer(serializers.ModelSerializer):
@@ -56,9 +50,7 @@ class ImageSetSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.ImageSet
         fields = '__all__'
-        read_only_fields = [
-            'id',
-        ] + MODIFIABLE_READ_ONLY_FIELDS
+        read_only_fields = MODIFIABLE_READ_ONLY_FIELDS
 
 
 class ImageSetSpatialSerializer(SpatialEntrySerializer):
@@ -67,6 +59,4 @@ class ImageSetSpatialSerializer(SpatialEntrySerializer):
     class Meta:
         model = models.ImageSetSpatial
         fields = '__all__'
-        read_only_fields = [
-            'id',
-        ] + MODIFIABLE_READ_ONLY_FIELDS
+        read_only_fields = MODIFIABLE_READ_ONLY_FIELDS

--- a/django-rgd-imagery/rgd_imagery/serializers/base.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/base.py
@@ -1,20 +1,30 @@
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rgd.models import ChecksumFile
-from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
+from rgd.serializers import (
+    MODIFIABLE_READ_ONLY_FIELDS,
+    TASK_EVENT_READ_ONLY_FIELDS,
+    ChecksumFileSerializer,
+    RelatedField,
+    SpatialEntrySerializer,
+)
 
 from .. import models
 
 
 class ImageSerializer(serializers.ModelSerializer):
-    file = ChecksumFileSerializer(read_only=True)
-    file_id = serializers.PrimaryKeyRelatedField(
-        queryset=ChecksumFile.objects.all(), write_only=True
-    )
+    file = RelatedField(queryset=ChecksumFile.objects.all(), serializer=ChecksumFileSerializer)
 
     class Meta:
         model = models.Image
         fields = '__all__'
+        read_only_fields = (
+            [
+                'id',
+            ]
+            + MODIFIABLE_READ_ONLY_FIELDS
+            + TASK_EVENT_READ_ONLY_FIELDS
+        )
 
 
 class ImageMetaSerializer(serializers.ModelSerializer):
@@ -35,21 +45,12 @@ class ImageMetaSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.ImageMeta
         fields = '__all__'
-        read_only_fields = [
-            'id',
-            'modified',
-            'created',
-            'driver',
-            'height',
-            'width',
-            'number_of_bands',
-        ]
+        # read_only_fields - This serializer should be used read-only
 
 
 class ImageSetSerializer(serializers.ModelSerializer):
-    images = ImageSerializer(many=True)
-    images_ids = serializers.PrimaryKeyRelatedField(
-        queryset=models.Image.objects.all(), write_only=True, many=True
+    images = RelatedField(
+        queryset=models.Image.objects.all(), serializer=ImageSerializer, many=True
     )
 
     class Meta:
@@ -57,13 +58,15 @@ class ImageSetSerializer(serializers.ModelSerializer):
         fields = '__all__'
         read_only_fields = [
             'id',
-            'modified',
-            'created',
-        ]
+        ] + MODIFIABLE_READ_ONLY_FIELDS
 
 
 class ImageSetSpatialSerializer(SpatialEntrySerializer):
-    image_set = ImageSetSerializer(read_only=True)
-    image_set_id = serializers.PrimaryKeyRelatedField(
-        queryset=models.ImageSet.objects.all(), write_only=True
-    )
+    image_set = RelatedField(queryset=models.ImageSet.objects.all(), serializer=ImageSetSerializer)
+
+    class Meta:
+        model = models.ImageSetSpatial
+        fields = '__all__'
+        read_only_fields = [
+            'id',
+        ] + MODIFIABLE_READ_ONLY_FIELDS

--- a/django-rgd-imagery/rgd_imagery/serializers/raster.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/raster.py
@@ -1,24 +1,27 @@
 from rest_framework import serializers
 from rgd.models import ChecksumFile
-from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
+from rgd.serializers import (
+    MODIFIABLE_READ_ONLY_FIELDS,
+    TASK_EVENT_READ_ONLY_FIELDS,
+    ChecksumFileSerializer,
+    RelatedField,
+    SpatialEntrySerializer,
+)
 
 from .. import models
 from .base import ImageSetSerializer
 
 
 class RasterSerializer(serializers.ModelSerializer):
-    image_set = ImageSetSerializer(read_only=True)
-    image_set_id = serializers.PrimaryKeyRelatedField(
-        queryset=models.ImageSet.objects.all(), write_only=True
-    )
-    ancillary_files = ChecksumFileSerializer(many=True, read_only=True)
-    ancillary_files_ids = serializers.PrimaryKeyRelatedField(
-        queryset=ChecksumFile.objects.all(), write_only=True, many=True
+    image_set = RelatedField(queryset=models.ImageSet.objects.all(), serializer=ImageSetSerializer)
+    ancillary_files = RelatedField(
+        queryset=ChecksumFile.objects.all(), serializer=ChecksumFileSerializer, many=True
     )
 
     class Meta:
         model = models.Raster
         fields = '__all__'
+        read_only_fields = MODIFIABLE_READ_ONLY_FIELDS + TASK_EVENT_READ_ONLY_FIELDS
 
 
 class RasterMetaSerializer(SpatialEntrySerializer):
@@ -29,3 +32,4 @@ class RasterMetaSerializer(SpatialEntrySerializer):
     class Meta:
         model = models.RasterMeta
         exclude = ['footprint', 'outline']
+        # read_only_fields - This serializer should be used read-only

--- a/django-rgd-imagery/rgd_imagery/serializers/raster.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/raster.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rgd.models import ChecksumFile
 from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
 
 from .. import models
@@ -6,8 +7,14 @@ from .base import ImageSetSerializer
 
 
 class RasterSerializer(serializers.ModelSerializer):
-    image_set = ImageSetSerializer()
-    ancillary_files = ChecksumFileSerializer(many=True)
+    image_set = ImageSetSerializer(read_only=True)
+    image_set_id = serializers.PrimaryKeyRelatedField(
+        queryset=models.ImageSet.objects.all(), write_only=True
+    )
+    ancillary_files = ChecksumFileSerializer(many=True, read_only=True)
+    ancillary_files_ids = serializers.PrimaryKeyRelatedField(
+        queryset=ChecksumFile.objects.all(), write_only=True, many=True
+    )
 
     class Meta:
         model = models.Raster
@@ -15,7 +22,9 @@ class RasterSerializer(serializers.ModelSerializer):
 
 
 class RasterMetaSerializer(SpatialEntrySerializer):
-    parent_raster = RasterSerializer()
+    """This is read-only."""
+
+    parent_raster = RasterSerializer(read_only=True)
 
     class Meta:
         model = models.RasterMeta

--- a/django-rgd-imagery/rgd_imagery/urls.py
+++ b/django-rgd-imagery/rgd_imagery/urls.py
@@ -35,6 +35,11 @@ urlpatterns = [
     #############
     # Other
     path(
+        'api/rgd_imagery',
+        rest.post.CreateImage.as_view(),
+        name='image-create',
+    ),
+    path(
         'api/rgd_imagery/<int:pk>',
         rest.get.GetImageMeta.as_view(),
         name='image-entry',
@@ -45,9 +50,29 @@ urlpatterns = [
         name='image-entry-data',
     ),
     path(
+        'api/rgd_imagery/image_set',
+        rest.post.CreateImageSet.as_view(),
+        name='image-set-create',
+    ),
+    path(
         'api/rgd_imagery/image_set/<int:pk>',
         rest.get.GetImageSet.as_view(),
         name='image-set',
+    ),
+    path(
+        'api/rgd_imagery/image_set_spatial',
+        rest.post.CreateImageSetSpatial.as_view(),
+        name='image-set-spatial-create',
+    ),
+    path(
+        'api/rgd_imagery/image_set_spatial/<int:pk>',
+        rest.get.GetImageSetSpatial.as_view(),
+        name='image-set-spatial',
+    ),
+    path(
+        'api/rgd_imagery/raster',
+        rest.post.CreateRaster.as_view(),
+        name='raster-create',
     ),
     path(
         'api/rgd_imagery/raster/<int:pk>',

--- a/django-rgd/rgd/rest/__init__.py
+++ b/django-rgd/rgd/rest/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['download', 'get', 'search']
+__all__ = ['download', 'get', 'search', 'post']
 
-from . import download, get, search
+from . import download, get, post, search

--- a/django-rgd/rgd/rest/get.py
+++ b/django-rgd/rgd/rest/get.py
@@ -38,3 +38,9 @@ class GetSpatialEntryFootprint(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.SpatialEntryFootprintSerializer
     lookup_field = 'spatial_id'
     queryset = models.SpatialEntry.objects.all()
+
+
+class GetSpatialAsset(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.SpatialAssetSerializer
+    lookup_field = 'spatial_id'
+    queryset = models.SpatialAsset.objects.all()

--- a/django-rgd/rgd/rest/get.py
+++ b/django-rgd/rgd/rest/get.py
@@ -10,6 +10,18 @@ class _PermissionMixin:
         return obj
 
 
+class GetCollection(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.CollectionSerializer
+    lookup_field = 'pk'
+    queryset = models.Collection.objects.all()
+
+
+class GetCollectionPermission(RetrieveAPIView, _PermissionMixin):
+    serializer_class = serializers.CollectionPermissionSerializer
+    lookup_field = 'pk'
+    queryset = models.CollectionPermission.objects.all()
+
+
 class GetChecksumFile(RetrieveAPIView, _PermissionMixin):
     serializer_class = serializers.ChecksumFileSerializer
     lookup_field = 'pk'

--- a/django-rgd/rgd/rest/post.py
+++ b/django-rgd/rgd/rest/post.py
@@ -1,0 +1,17 @@
+from rest_framework.generics import CreateAPIView
+from rgd import models, serializers
+
+
+class CreateCollection(CreateAPIView):
+    queryset = models.Collection.objects.all()
+    serializer_class = serializers.CollectionSerializer
+
+
+class CreateCollectionPermission(CreateAPIView):
+    queryset = models.CollectionPermission.objects.all()
+    serializer_class = serializers.CollectionPermissionSerializer
+
+
+class CreateChecksumFile(CreateAPIView):
+    queryset = models.ChecksumFile.objects.all()
+    serializer_class = serializers.ChecksumFileSerializer

--- a/django-rgd/rgd/rest/post.py
+++ b/django-rgd/rgd/rest/post.py
@@ -15,3 +15,8 @@ class CreateCollectionPermission(CreateAPIView):
 class CreateChecksumFile(CreateAPIView):
     queryset = models.ChecksumFile.objects.all()
     serializer_class = serializers.ChecksumFileSerializer
+
+
+class CreateSpatialAsset(CreateAPIView):
+    queryset = models.SpatialAsset.objects.all()
+    serializer_class = serializers.SpatialAssetSerializer

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -5,7 +5,24 @@ from rest_framework import serializers
 from . import models, utility
 
 
+class CollectionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Collection
+        fields = '__all__'
+
+
+class CollectionPermissionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.CollectionPermission
+        fields = '__all__'
+
+
 class ChecksumFileSerializer(serializers.ModelSerializer):
+    """Serializer for ChecksumFiles.
+
+    On POST, this can only handle URL files.
+    """
+
     def to_representation(self, value):
         ret = super().to_representation(value)
         ret['download_url'] = value.get_url()
@@ -14,7 +31,15 @@ class ChecksumFileSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.ChecksumFile
         fields = '__all__'
-        read_only_fields = ['id', 'checksum', 'last_validation', 'modified', 'created']
+        read_only_fields = [
+            'id',
+            'checksum',
+            'last_validation',
+            'modified',
+            'created',
+            'status',
+            'failure_reason',
+        ]
 
 
 class SpatialEntrySerializer(serializers.ModelSerializer):

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -4,6 +4,32 @@ from rest_framework import serializers
 
 from . import models, utility
 
+MODIFIABLE_READ_ONLY_FIELDS = ['modified', 'created']
+TASK_EVENT_READ_ONLY_FIELDS = ['status', 'failure_reason']
+SPATIAL_ENTRY_EXCLUDE = ['footprint', 'outline']
+
+
+class RelatedField(serializers.PrimaryKeyRelatedField):
+    """Handle GET/POST in a single field.
+
+    Reference: https://stackoverflow.com/a/52246232
+    """
+
+    def __init__(self, **kwargs):
+        self.serializer = kwargs.pop('serializer', None)
+        if self.serializer is not None and not issubclass(self.serializer, serializers.Serializer):
+            raise TypeError('"serializer" is not a valid serializer class')
+
+        super().__init__(**kwargs)
+
+    def use_pk_only_optimization(self):
+        return False if self.serializer else True
+
+    def to_representation(self, instance):
+        if self.serializer:
+            return self.serializer(instance, context=self.context).data
+        return super().to_representation(instance)
+
 
 class CollectionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -12,9 +38,8 @@ class CollectionSerializer(serializers.ModelSerializer):
 
 
 class CollectionPermissionSerializer(serializers.ModelSerializer):
-    collection = CollectionSerializer(read_only=True)
-    collection_id = serializers.PrimaryKeyRelatedField(
-        queryset=models.Collection.objects.all(), write_only=True
+    collection = RelatedField(
+        queryset=models.Collection.objects.all(), serializer=CollectionSerializer
     )
 
     class Meta:
@@ -36,15 +61,15 @@ class ChecksumFileSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.ChecksumFile
         fields = '__all__'
-        read_only_fields = [
-            'id',
-            'checksum',
-            'last_validation',
-            'modified',
-            'created',
-            'status',
-            'failure_reason',
-        ]
+        read_only_fields = (
+            [
+                'id',
+                'checksum',
+                'last_validation',
+            ]
+            + MODIFIABLE_READ_ONLY_FIELDS
+            + TASK_EVENT_READ_ONLY_FIELDS
+        )
 
 
 class SpatialEntrySerializer(serializers.ModelSerializer):
@@ -65,7 +90,7 @@ class SpatialEntrySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.SpatialEntry
-        exclude = ['footprint', 'outline']
+        exclude = SPATIAL_ENTRY_EXCLUDE
 
 
 class SpatialEntryFootprintSerializer(SpatialEntrySerializer):
@@ -76,18 +101,17 @@ class SpatialEntryFootprintSerializer(SpatialEntrySerializer):
 
     class Meta:
         model = models.SpatialEntry
-        exclude = ['footprint', 'outline']
+        exclude = SPATIAL_ENTRY_EXCLUDE
 
 
 class SpatialAssetSerializer(SpatialEntrySerializer):
-    file = ChecksumFileSerializer(read_only=True)
-    file_id = serializers.PrimaryKeyRelatedField(
-        queryset=models.ChecksumFile.objects.all(), write_only=True
+    file = RelatedField(
+        queryset=models.ChecksumFile.objects.all(), serializer=ChecksumFileSerializer
     )
 
     class Meta:
         model = models.SpatialAsset
-        exclude = ['footprint', 'outline']
+        exclude = SPATIAL_ENTRY_EXCLUDE
 
 
 utility.make_serializers(globals(), models)

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -74,4 +74,10 @@ class SpatialEntryFootprintSerializer(SpatialEntrySerializer):
         exclude = ['footprint', 'outline']
 
 
+class SpatialAssetSerializer(SpatialEntrySerializer):
+    class Meta:
+        model = models.SpatialAsset
+        exclude = ['footprint', 'outline']
+
+
 utility.make_serializers(globals(), models)

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -63,7 +63,6 @@ class ChecksumFileSerializer(serializers.ModelSerializer):
         fields = '__all__'
         read_only_fields = (
             [
-                'id',
                 'checksum',
                 'last_validation',
             ]

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -12,6 +12,11 @@ class CollectionSerializer(serializers.ModelSerializer):
 
 
 class CollectionPermissionSerializer(serializers.ModelSerializer):
+    collection = CollectionSerializer(read_only=True)
+    collection_id = serializers.PrimaryKeyRelatedField(
+        queryset=models.Collection.objects.all(), write_only=True
+    )
+
     class Meta:
         model = models.CollectionPermission
         fields = '__all__'
@@ -75,6 +80,11 @@ class SpatialEntryFootprintSerializer(SpatialEntrySerializer):
 
 
 class SpatialAssetSerializer(SpatialEntrySerializer):
+    file = ChecksumFileSerializer(read_only=True)
+    file_id = serializers.PrimaryKeyRelatedField(
+        queryset=models.ChecksumFile.objects.all(), write_only=True
+    )
+
     class Meta:
         model = models.SpatialAsset
         exclude = ['footprint', 'outline']

--- a/django-rgd/rgd/urls.py
+++ b/django-rgd/rgd/urls.py
@@ -45,4 +45,29 @@ urlpatterns = [
         rest.download.download_checksum_file,
         name='checksum-file-data',
     ),
+    path(
+        'api/rgd/checksum_file',
+        rest.post.CreateChecksumFile.as_view(),
+        name='checksum-create',
+    ),
+    path(
+        'api/rgd/collection',
+        rest.post.CreateCollection.as_view(),
+        name='collection-create',
+    ),
+    path(
+        'api/rgd/collection/<int:pk>',
+        rest.get.GetCollection.as_view(),
+        name='collection',
+    ),
+    path(
+        'api/rgd/collection_permission',
+        rest.post.CreateCollectionPermission.as_view(),
+        name='collection-permission-create',
+    ),
+    path(
+        'api/rgd/collection_permission/<int:pk>',
+        rest.get.GetCollectionPermission.as_view(),
+        name='collection-permission',
+    ),
 ]

--- a/django-rgd/rgd/urls.py
+++ b/django-rgd/rgd/urls.py
@@ -70,4 +70,14 @@ urlpatterns = [
         rest.get.GetCollectionPermission.as_view(),
         name='collection-permission',
     ),
+    path(
+        'api/rgd/spatial_asset',
+        rest.post.CreateSpatialAsset.as_view(),
+        name='spatial-asset-create',
+    ),
+    path(
+        'api/rgd/spatial_asset/<int:pk>',
+        rest.get.GetSpatialAsset.as_view(),
+        name='spatial-asset',
+    ),
 ]


### PR DESCRIPTION
Partially address #452 

This adds the POST endpoints we hope to expose in the Python client for the work in https://github.com/ResonantGeoData/RGD-ScrumBoard/issues/29

Adds new POST endpoints for (and GET when not already present):

- `Collection` and `CollectionPermission`
- `ChecksumFile` (URL files only)
- `SpatialAsset`
- `Image`
- `ImageSet`
- `ImageSetSpatial`
- `Raster`

cc @AlmightyYakob 