### PR TITLE
Fix error in order_datetimes, add doctest

### DIFF
--- a/rgd-client/rgd_client/utils.py
+++ b/rgd-client/rgd_client/utils.py
@@ -94,9 +94,18 @@ def datetime_to_time(value: object):
 
 
 def order_datetimes(value1: object, value2: object):
-    """Sort 2 objects if they are datetimes."""
+    """
+    Sort 2 objects if they are datetimes.
+
+    Example:
+        >>> from rgd_client.utils import *  # NOQA
+        >>> value1 = datetime.fromisoformat('2000-01-01T00:13:30')
+        >>> value2 = datetime.fromisoformat('1999-01-01T00:13:30')
+        >>> result = order_datetimes(value1, value2)
+        >>> assert len(result) == 2
+    """
     if isinstance(value1, datetime) and isinstance(value2, datetime):
-        return value1, value2 if value1 < value2 else value2, value1
+        return (value1, value2) if value1 < value2 else (value2, value1)
 
     return value1, value2
 


### PR DESCRIPTION
The previous usage of `order_datetimes` used the syntax `value1, value2 if value1 < value2 else value2, value1`, which actually will return a 3-tuple of (value1, max(value1, value2), value2) because the comma operator has lower precidence than inline if staements.

I also added a doctest with the code I used to verify that it was failing and then ensure that the fix worked. 

We should be able to get this test to run in the CI without too much trouble: Add `xdoctest` as a dependency and give `--xdoctest` as an argument to pytest. I haven't used tox in awhile, so not sure if that complicates anything. 