### PR TITLE
Pin pooch to <1.5.0

### DIFF
--- a/django-rgd/setup.py
+++ b/django-rgd/setup.py
@@ -61,7 +61,8 @@ setup(
         'djangorestframework',
         'drf-yasg',
         'GDAL',
-        'pooch',
+        # TODO: Unpin once scikit-image and kwimage are updated
+        'pooch<1.5.0',
         'psycopg2',
         'python-magic',
         'flower',


### PR DESCRIPTION
Due to a change in [`pooch`](https://github.com/fatiando/pooch/issues/252), `scikit-image` is [broken](https://github.com/scikit-image/scikit-image/issues/5528) on import. This was [fixed](https://github.com/scikit-image/scikit-image/pull/5529) in `scikit-image`, but a release hasn't been cut yet. This currently breaks our tests.

The breaking change was introduced in version `1.5.0` of `pooch`, so PR restricts the version accordingly.