### PR TITLE
Stop processing unused images

### DIFF
--- a/django-rgd-imagery/rgd_imagery/tasks/etl.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/etl.py
@@ -301,9 +301,8 @@ def _validate_image_set_is_raster(image_set):
 
     base_image = images.pop()
     first_meta = _extract_raster_meta(base_image)
-    for image in images:
-        _extract_raster_meta(image)
-
+    # for image in images:
+    #     _extract_raster_meta(image)
     return first_meta
 
 


### PR DESCRIPTION
Images are opened and checked to be rasters but that metadata is not used. This can dramatically slow down data ingest times. To speed it up, I am commenting this out.

Note that, the images could be non-geospatial and this now will not throw an error.