### PR TITLE
Add setting to automatically approve user sign ups

### DIFF
--- a/django-rgd/README.md
+++ b/django-rgd/README.md
@@ -51,7 +51,7 @@ The RGD core app has a few optional settings:
 
 - `RGD_GLOBAL_READ_ACCESS`: option to give all users access to files that lack permissions (otherwise only admin users can access these files)
 - `RGD_FILE_FIELD_PREFIX`: the path prefix when uploading files to the project's S3 storage.
-
+- `RGD_AUTO_APPROVE_SIGN_UP`: automatically approve all user sign ups.
 
 ## Models
 

--- a/django-rgd/rgd/signals.py
+++ b/django-rgd/rgd/signals.py
@@ -1,4 +1,5 @@
 from allauth.account.signals import user_signed_up
+from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -14,6 +15,9 @@ def _post_save_checksum_file(sender, instance, *args, **kwargs):
 
 @receiver(user_signed_up)
 def set_new_user_inactive(sender, **kwargs):
+    if getattr(settings, 'RGD_AUTO_APPROVE_SIGN_UP', None):
+        # Use setting `RGD_AUTO_APPROVE_SIGN_UP` to automatically approve all users
+        return
     user = kwargs.get('user')
     try:
         models.WhitelistedEmail.objects.get(email=user.email)


### PR DESCRIPTION
On some instances, like RD-OpenGeo, we may want to automatically allow users to sign up