### PR TITLE
Upload code coverage and model graphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           CELERY_BROKER_URL: amqp://localhost:5672/
           DATABASE_HOST: localhost
       - name: Stash coverage
-        uses: actions/download-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: .coverage.${{ matrix.rgd-module }}
           path: django-${{ matrix.rgd-module }}/tests/.coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run linting
         run: |
           tox -e lint
-  check-migrations:
+  check-migrations-graph:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -57,12 +57,18 @@ jobs:
       - name: Run check migrations
         run: |
           tox -e check-migrations
+          tox -e graph-models
         env:
           DJANGO_DATABASE_URL: postgres://postgres:postgres@localhost:5432/django
           DJANGO_MINIO_STORAGE_ENDPOINT: localhost:9000
           DJANGO_MINIO_STORAGE_ACCESS_KEY: minioAccessKey
           DJANGO_MINIO_STORAGE_SECRET_KEY: minioSecretKey
           DJANGO_STORAGE_BUCKET_NAME: django-storage
+      - name: Upload model graphs
+        uses: actions/upload-artifact@v2
+        with:
+          name: graphs
+          path: .tox/graphs/*.png
   test:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
           MINIO_STORAGE_SECRET_KEY: minioSecretKey
           CELERY_BROKER_URL: amqp://localhost:5672/
           DATABASE_HOST: localhost
+      - name: Stash coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: .coverage.${{ matrix.rgd-module }}
+          path: django-${{ matrix.rgd-module }}/tests/.coverage
       - name: Upload Coverage
         run: |
           codecov --verbose --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,4 @@ jobs:
           DATABASE_HOST: localhost
       - name: Upload Coverage
         run: |
-          codecov --verbose -Z --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}
+          codecov --verbose --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,4 @@ jobs:
           DATABASE_HOST: localhost
       - name: Upload Coverage
         run: |
-          codecov --verbose --file ${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}
+          codecov --verbose -Z --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
         with:
           name: .coverage.${{ matrix.rgd-module }}
           path: django-${{ matrix.rgd-module }}/tests/.coverage
-      - name: Upload to codecov
-        run: |
-          codecov --verbose --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: django-${{ matrix.rgd-module }}/tests/.coverage
+          flags: ${{ matrix.rgd-module }}
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,10 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: .coverage.${{ matrix.rgd-module }}
-          path: django-${{ matrix.rgd-module }}/tests/.coverage
+          path: django-${{ matrix.rgd-module }}/tests/coverage.xml
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: django-${{ matrix.rgd-module }}/tests/.coverage
+          files: django-${{ matrix.rgd-module }}/tests/coverage.xml
           flags: ${{ matrix.rgd-module }}
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,6 @@ jobs:
           MINIO_STORAGE_SECRET_KEY: minioSecretKey
           CELERY_BROKER_URL: amqp://localhost:5672/
           DATABASE_HOST: localhost
-      # - name: Upload Coverage
-      #   run: |
-      #     codecov
+      - name: Upload Coverage
+        run: |
+          codecov --verbose --file ${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install tox
+      - name: Install graphviz
+        run: |
+          sudo apt update
+          sudo apt-get install --no-install-recommends --yes graphviz libgraphviz-dev
       - name: Run check migrations
         run: |
           tox -e check-migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install --no-install-recommends --yes graphviz libgraphviz-dev
-      - name: Run check migrations
+      - name: Run check migrations and graph models
         run: |
           tox -e check-migrations
           tox -e graph-models
@@ -128,6 +128,6 @@ jobs:
         with:
           name: .coverage.${{ matrix.rgd-module }}
           path: django-${{ matrix.rgd-module }}/tests/.coverage
-      - name: Upload Coverage
+      - name: Upload to codecov
         run: |
           codecov --verbose --file django-${{ matrix.rgd-module }}/tests/.coverage -F ${{ matrix.rgd-module }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [![logo](https://raw.githubusercontent.com/ResonantGeoData/ResonantGeoData/main/logos/RGD_Logo.png)](https://github.com/ResonantGeoData/ResonantGeoData/)
 
-[![codecov](https://codecov.io/gh/ResonantGeoData/ResonantGeoData/branch/master/graph/badge.svg)](https://codecov.io/gh/ResonantGeoData/ResonantGeoData)
+[![codecov](https://codecov.io/gh/ResonantGeoData/ResonantGeoData/branch/main/graph/badge.svg?token=GODOWLJ5JT)](https://codecov.io/gh/ResonantGeoData/ResonantGeoData)
 [![ci](https://github.com/ResonantGeoData/ResonantGeoData/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ResonantGeoData/ResonantGeoData/actions/workflows/ci.yml)
 
 > Geospatial Data API in Django

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,4 +12,5 @@ coverage:
       default:
         threshold: 25
         only_pulls: true
-
+  fixes:
+    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/ResonantGeoData/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 fixes:
-    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/ResonantGeoData/::"
+    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/::"
 comment: false
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,3 @@
-fixes:
-    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/::"
 comment: false
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+fixes:
+    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/ResonantGeoData/::"
 comment: false
 coverage:
   status:
@@ -12,5 +14,3 @@ coverage:
       default:
         threshold: 25
         only_pulls: true
-  fixes:
-    - "/System/Volumes/Data/home/runner/work/ResonantGeoData/ResonantGeoData/::"

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
 commands =
     pytest --cov=rgd {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd
-    coverage xml -o {toxworkdir}/coverage.xml
+    coverage xml -o {toxworkdir}/coverage/django-rgd.xml
 
 [testenv:test-rgd-3d]
 changedir = django-rgd-3d/tests
@@ -99,7 +99,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_3d {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-3d
-    coverage xml -o {toxworkdir}/coverage.xml
+    coverage xml -o {toxworkdir}/coverage/django-rgd-3d.xml
 
 [testenv:test-rgd-fmv]
 changedir = django-rgd-fmv/tests
@@ -109,7 +109,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_fmv {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-fmv
-    coverage xml -o {toxworkdir}/coverage.xml
+    coverage xml -o {toxworkdir}/coverage/django-rgd-fmv.xml
 
 [testenv:test-rgd-geometry]
 changedir = django-rgd-geometry/tests
@@ -119,7 +119,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_geometry {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-geometry
-    coverage xml -o {toxworkdir}/coverage.xml
+    coverage xml -o {toxworkdir}/coverage/django-rgd-geometry.xml
 
 [testenv:test-rgd-imagery]
 changedir = django-rgd-imagery/tests
@@ -131,7 +131,15 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_imagery {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-imagery
-    coverage xml -o {toxworkdir}/coverage.xml
+    coverage xml -o {toxworkdir}/coverage/django-rgd-imagery.xml
+
+[testenv:coverage-report]
+deps =
+    pytest-cov
+commands =
+    coverage combine ./django-rgd/tests/.coverage ./django-rgd-3d/tests/.coverage ./django-rgd-geometry/tests/.coverage ./django-rgd-imagery/tests/.coverage ./django-rgd-fmv/tests/.coverage
+    coverage html -d {toxworkdir}/htmlcov/all
+    coverage xml -o {toxworkdir}/coverage/all.xml
 
 [testenv:dev]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,7 @@ deps =
 commands =
     pytest --cov=rgd {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd
-    coverage xml -o {toxworkdir}/coverage/django-rgd.xml
+    coverage xml -o coverage.xml
 
 [testenv:test-rgd-3d]
 changedir = django-rgd-3d/tests
@@ -127,7 +127,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_3d {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-3d
-    coverage xml -o {toxworkdir}/coverage/django-rgd-3d.xml
+    coverage xml -o coverage.xml
 
 [testenv:test-rgd-fmv]
 changedir = django-rgd-fmv/tests
@@ -137,7 +137,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_fmv {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-fmv
-    coverage xml -o {toxworkdir}/coverage/django-rgd-fmv.xml
+    coverage xml -o coverage.xml
 
 [testenv:test-rgd-geometry]
 changedir = django-rgd-geometry/tests
@@ -147,7 +147,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_geometry {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-geometry
-    coverage xml -o {toxworkdir}/coverage/django-rgd-geometry.xml
+    coverage xml -o coverage.xml
 
 [testenv:test-rgd-imagery]
 changedir = django-rgd-imagery/tests
@@ -159,7 +159,7 @@ deps =
 commands =
     pytest --cov=rgd --cov=rgd_imagery {posargs}
     coverage html -d {toxworkdir}/htmlcov/django-rgd-imagery
-    coverage xml -o {toxworkdir}/coverage/django-rgd-imagery.xml
+    coverage xml -o coverage.xml
 
 [testenv:coverage-report]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,34 @@ passenv =
 commands =
     {envpython} ./example_project/manage.py makemigrations --check --dry-run
 
+[testenv:graph-models]
+deps =
+    -e ./django-rgd[configuration]
+    -e ./django-rgd-3d
+    -e ./django-rgd-fmv
+    -e ./django-rgd-geometry
+    -e ./django-rgd-imagery
+    -e ./example_project[graph]
+passenv =
+    DJANGO_CONFIGURATION
+    DJANGO_DATABASE_URL
+    DJANGO_CELERY_BROKER_URL
+    DJANGO_MINIO_STORAGE_ENDPOINT
+    DJANGO_MINIO_STORAGE_ACCESS_KEY
+    DJANGO_MINIO_STORAGE_SECRET_KEY
+    DJANGO_STORAGE_BUCKET_NAME
+    DJANGO_MINIO_STORAGE_MEDIA_URL
+whitelist_externals = mkdir
+commands =
+    mkdir -p {toxworkdir}/graphs/
+    {envpython} ./example_project/manage.py graph_models rgd -o {toxworkdir}/graphs/rgd.png
+    {envpython} ./example_project/manage.py graph_models rgd_3d -o {toxworkdir}/graphs/rgd-3d.png
+    {envpython} ./example_project/manage.py graph_models rgd_fmv -o {toxworkdir}/graphs/rgd-fmv.png
+    {envpython} ./example_project/manage.py graph_models rgd_geometry -o {toxworkdir}/graphs/rgd-geometry.png
+    {envpython} ./example_project/manage.py graph_models rgd_imagery -o {toxworkdir}/graphs/rgd-imagery.png
+    {envpython} ./example_project/manage.py graph_models rgd rgd_3d rgd_fmv rgd_geometry rgd_imagery -g -o {toxworkdir}/graphs/rgd-all.png
+
+
 [testenv:test-rgd]
 changedir = django-rgd/tests
 deps =


### PR DESCRIPTION
Resolve #440: this finally fixes our code coverage reports and properly uploads the full report to codecov

Further, I added a step to the CI to create model graphs of each of the apps and upload those images as build artifacts. These can be useful to see when making changes to models