### PR TITLE
Update GeoDjangoMixin

### DIFF
--- a/django-rgd/rgd/configuration/configuration.py
+++ b/django-rgd/rgd/configuration/configuration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Type
 
 try:
@@ -18,23 +17,10 @@ class GeoDjangoMixin(ConfigMixin):
     @staticmethod
     def before_binding(configuration: Type[ComposedConfiguration]):
         configuration.INSTALLED_APPS += ['django.contrib.gis']
-        try:
-            import re
+        import osgeo
 
-            import osgeo
-
-            libsdir = os.path.join(
-                os.path.dirname(os.path.dirname(osgeo._gdal.__file__)), 'GDAL.libs'
-            )
-            libs = {
-                re.split(r'-|\.', name)[0]: os.path.join(libsdir, name)
-                for name in os.listdir(libsdir)
-            }
-            configuration.GDAL_LIBRARY_PATH = libs['libgdal']
-            configuration.GEOS_LIBRARY_PATH = libs['libgeos_c']
-        except Exception:
-            # TODO: Log that we aren't using the expected GDAL wheel?
-            pass
+        configuration.GDAL_LIBRARY_PATH = osgeo.GDAL_LIBRARY_PATH
+        configuration.GEOS_LIBRARY_PATH = osgeo.GEOS_LIBRARY_PATH
 
 
 class SwaggerMixin(ConfigMixin):


### PR DESCRIPTION
I've noticed a couple of things while using this mixin downstream.

First, if importing `osgeo` fails, the `ImportError` is caught and ignored, subsequently causing the following error

```
django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library (tried "gdal", "GDAL",
"gdal3.2.0", "gdal3.1.0", "gdal3.0.0", "gdal2.4.0", "gdal2.3.0", "gdal2.2.0", "gdal2.1.0", "gdal2.0.0").
Is GDAL installed? If it is, try setting GDAL_LIBRARY_PATH in your settings.
```

It seems that if this import fails, and these two environment variables aren't set, then this failure will always occur. The proposed solution in this PR is to remove the `try/except`, and just let any import error bubble up. Since apparently for RGD the required version of `GDAL` is fairly high, this import structure should be fine. @banesullivan what was the minimum version that was discussed? Another option might be to check for the existence of these environment variables, if they may be configured in other ways, and only throw an exception if both the import fails, and these variables are missing.


Second, it seems that the existing code used to set the two environment variables is essentially taken directly from the top level of the `osgeo` package. Since these two variables are created in that module, I've updated the `GeoDjangoMixin` to just use these existing variables, instead of running the same code again. If we're pinning `GDAL` to a high minimum version, I think leveraging this from the `osgeo` package should be fine, but there might be edge cases I'm unaware of. @manthey I've tagged you for review, since you may know more about this.