### PR TITLE
add new base map names to RGD from newest GeoJS version

### DIFF
--- a/django-rgd/rgd/templates/rgd/_base/base.html
+++ b/django-rgd/rgd/templates/rgd/_base/base.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/0.20.0/geo.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/geojs/1.4.3/geo.min.js"></script>
 
     <script>
       var host = window.location.protocol + "//" + window.location.host;

--- a/django-rgd/rgd/templates/rgd/_include/empty_viewer.html
+++ b/django-rgd/rgd/templates/rgd/_include/empty_viewer.html
@@ -27,10 +27,10 @@
     for(const option in options){
       var newOption = document.createElement('option');
       newOption.value = option;
-      newOption.text = option;
+      newOption.text = options[option].name;
     document.getElementById('basemapDropdown').appendChild(newOption)
     }
-     
+
     // Initialize the map
     let map = geo.map({
       node: '#map',


### PR DESCRIPTION
Pull newest GeoJS release (1.4.3) and update basemap names to the `osmLayer.tileSources.item.name` field 
From https://github.com/ResonantGeoData/ResonantGeoData/issues/522#issuecomment-929348471