### PR TITLE
Specify minimum pystac version

### DIFF
--- a/django-rgd-imagery/setup.py
+++ b/django-rgd-imagery/setup.py
@@ -53,7 +53,7 @@ setup(
         'large-image-source-tiff>=1.8.1.dev7',
         'tifftools>=1.2.0',
         'numpy',
-        'pystac',
+        'pystac>=1.1.0',
         'shapely',
     ],
     extras_require={


### PR DESCRIPTION
Prior to this, since no minimum version is specified, it's possible for pip to install `pystac==0.5.6`. This is a problem for this line of code:

https://github.com/ResonantGeoData/ResonantGeoData/blob/c29cbb5ef5298c902cc9f0435bf9378bfbc61fc6/django-rgd-imagery/rgd_imagery/serializers/stac/item/__init__.py#L8

In version `0.5.6`, this class doesn't exist in this file (it's introduced in the next release, `v1.0.0-beta1`) so this import fails.