### PR TITLE
Disable vsi path tilesource code so NITF images to load properly

### DIFF
--- a/django-rgd-imagery/rgd_imagery/large_image_utilities.py
+++ b/django-rgd-imagery/rgd_imagery/large_image_utilities.py
@@ -1,22 +1,28 @@
 from contextlib import contextmanager
 
 import large_image
-from large_image.exceptions import TileSourceException
 from large_image.tilesource import FileTileSource
-from large_image_source_gdal import GDALFileTileSource
 from rgd_imagery.models import Image
+
+# from large_image.exceptions import TileSourceException
+# from large_image_source_gdal import GDALFileTileSource
 
 
 def get_tilesource_from_image(
     image: Image, projection: str = None, style: str = None
 ) -> FileTileSource:
     # Make sure projection is None by default to use source projection
-    try:
-        file_path = image.file.get_vsi_path(internal=True)
-        return GDALFileTileSource(file_path, projection=projection, encoding='PNG', style=style)
-    except TileSourceException:
-        with image.file.yield_local_path() as file_path:
-            return large_image.open(str(file_path), style=style)
+    # try:
+    #     file_path = image.file.get_vsi_path(internal=True)
+    #     return GDALFileTileSource(file_path, projection=projection, encoding='PNG', style=style)
+    # except TileSourceException:
+    #    with image.file.yield_local_path() as file_path:
+    #        return large_image.open(str(file_path), style=style)
+
+    # NOTE: this temporarily replaces the above code and is a workaround to allow NITF files to be
+    # viewed (they don't work properly with VSI paths).
+    with image.file.yield_local_path() as file_path:
+        return large_image.open(str(file_path), style=style)
 
 
 @contextmanager


### PR DESCRIPTION
Using vsi paths to load the NITF tiles makes the server hang indefinitely. This is a temporary measure until a long-term solution (maybe doing away with VSI and writing a custom fuse module) is implemented.