### PR TITLE
Add missing psutil dep in django-rgd setup.py

### DIFF
--- a/django-rgd/setup.py
+++ b/django-rgd/setup.py
@@ -67,6 +67,7 @@ setup(
         'psycopg2',
         'python-magic',
         'flower',
+        'psutil',
         # Production-only
         'django-s3-file-field[minio]',
     ],


### PR DESCRIPTION
`psutil` is used in `django-rgd`, but not listed as a dependency. Recently, the CI for https://github.com/girder/Danesfield has been failing, due to missing the `psutil` module. I'm not sure what caused this to happen spontaneously, but my best guess is an upstream dep recently removed `psutil` from _it's_ dependencies.

This PR adds `psutil` to `install_requires`.