### PR TITLE
Add support for plugin dependencies

### DIFF
--- a/django-rgd-imagery/client/rgd_imagery_client/plugin.py
+++ b/django-rgd-imagery/client/rgd_imagery_client/plugin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import tempfile
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-from rgd_client.plugin import RGDPlugin
+from rgd_client.plugin import RgdPlugin
 from rgd_client.types import DATETIME_OR_STR_TUPLE, SEARCH_PREDICATE_CHOICE
 from rgd_client.utils import (
     download_checksum_file_to_path,
@@ -23,7 +23,7 @@ class RasterDownload:
     ancillary: List[Path]
 
 
-class ImageryPlugin(RGDPlugin):
+class ImageryPlugin(RgdPlugin):
     """The django-rgd-imagery client plugin."""
 
     def list_image_tiles(self, image_id: Union[str, int]) -> Dict:

--- a/django-rgd-imagery/client/rgd_imagery_client/plugin.py
+++ b/django-rgd-imagery/client/rgd_imagery_client/plugin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import tempfile
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-from rgd_client.session import RgdClientSession
+from rgd_client.plugin import CorePlugin, RGDPlugin
 from rgd_client.types import DATETIME_OR_STR_TUPLE, SEARCH_PREDICATE_CHOICE
 from rgd_client.utils import (
     download_checksum_file_to_path,
@@ -23,12 +23,15 @@ class RasterDownload:
     ancillary: List[Path]
 
 
-class ImageryPlugin:
+class PluginDependencies:
+    rgd = CorePlugin
+
+
+class ImageryPlugin(RGDPlugin):
     """The django-rgd-imagery client plugin."""
 
-    def __init__(self, session: RgdClientSession):
-        # session.base_url not modified due to varying url prefixes
-        self.session = session
+    # Declare plugins
+    plugins = PluginDependencies
 
     def list_image_tiles(self, image_id: Union[str, int]) -> Dict:
         """List geodata imagery tiles."""

--- a/django-rgd-imagery/client/rgd_imagery_client/plugin.py
+++ b/django-rgd-imagery/client/rgd_imagery_client/plugin.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import tempfile
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-from rgd_client.plugin import CorePlugin, RGDPlugin
+from rgd_client.plugin import RGDPlugin
 from rgd_client.types import DATETIME_OR_STR_TUPLE, SEARCH_PREDICATE_CHOICE
 from rgd_client.utils import (
     download_checksum_file_to_path,
@@ -23,15 +23,8 @@ class RasterDownload:
     ancillary: List[Path]
 
 
-class PluginDependencies:
-    rgd = CorePlugin
-
-
 class ImageryPlugin(RGDPlugin):
     """The django-rgd-imagery client plugin."""
-
-    # Declare plugins
-    plugins = PluginDependencies
 
     def list_image_tiles(self, image_id: Union[str, int]) -> Dict:
         """List geodata imagery tiles."""

--- a/django-rgd/client/PLUGINS.md
+++ b/django-rgd/client/PLUGINS.md
@@ -4,14 +4,17 @@ The behavior of `rgd_client` can be extended through plugins. A plugin is python
 
 
 ## Defining a Plugin
-A plugin is defined by creating two classes. The first is the definition of the core plugin itself
+A plugin is defined by creating two classes. The first is the definition of the plugin itself, which must extend the base `RgdPlugin` class
 
 
 ### The Plugin Class
 ```python
-class MyPlugin:
-    def __init__(self, session: RgdClientSession):
-        self.session = session
+from rgd_client.plugin import RgdPlugin
+
+
+class MyPlugin(RgdPlugin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Optionally extend the existing base url
         self.session.base_url += 'foo/'
@@ -20,7 +23,7 @@ class MyPlugin:
         return self.session.get('bar')
 ```
 
-Each plugin is instantiated with a `RgdClientSession` instance. This is a copy of the core client session, which is instantiated once and copied to all loaded plugins. The core client session is instantiated with the base url of the RGD API you're trying to access, as well as authentication if `username` and `password` are supplied to `create_rgd_client`. This session copy is supplied to the plugin for it's own use, as well as possible modification. Since it's common for plugins to urls under a specific prefix, the session base url can be extended, as shown in the example. The session can be modified in any desired way, as it's a copy and will not affect the core client session.
+Each plugin is instantiated with a `RgdClientSession` instance at `self.session`. This is a copy of the core client session, which is instantiated once and copied to all loaded plugins. The core client session is instantiated with the base url of the RGD API you're trying to access, as well as authentication if `username` and `password` are supplied to `create_rgd_client`. This session copy is supplied to the plugin for it's own use, as well as possible modification. Since it's common for plugins to urls under a specific prefix, the session base url can be extended, as shown in the example. The session can be modified in any desired way, as it's a copy and will not affect the core client session.
 
 
 ### The Client Class
@@ -116,7 +119,7 @@ Now, all plugin namespaces and methods will be shown in your IDE.
 
 
 ### Sibling plugins
-There may be a circumstance where you'd like to make use of another plugin from within your own plugin. For example, if you wanted to wrap the core `search` method in your own `my_search` function. This can be done by defining a *plugin dependency*.
+There may be a circumstance where you'd like to make use of another plugin from within your own plugin. For example, if you wanted to wrap the core `search` method in your own `my_search` method. This can be done by defining a *plugin dependency*.
 
 This is very simple to do, just place a definition of the plugin you'd like to use within your own plugin definition. Here's an example that illustrates the situation metioned above
 
@@ -138,4 +141,6 @@ class MyClient:
 
 ```
 
-When `create_rgd_client` is called, it searches all registered plugins for members that inherit `RgdPlugin`, and instantiates them if it does. So, as long as the plugin you want to use is installed with `pip`, or is provided in `extra_plugins`, it will be injected into your plugin.
+When `create_rgd_client` is called, it searches all registered plugins for members that inherit `RgdPlugin`, and instantiates them. In this case, it sees that `MyPlugin.rgd` is set to `CorePlugin`, which inherits `RgdPlugin`, so it replaces `MyPlugin.rgd` with an *instance* of `CorePlugin`, instead of the class `CorePlugin` itself. This is only done on the plugin instances within the client, not the plugin classes themselves, so each plugin class remains untouched.
+
+As long as the plugin you want to use is installed with `pip`, or is provided in `extra_plugins`, it will be injected into your plugin.

--- a/django-rgd/client/PLUGINS.md
+++ b/django-rgd/client/PLUGINS.md
@@ -113,3 +113,29 @@ client: Client = create_rgd_client()
 ```
 
 Now, all plugin namespaces and methods will be shown in your IDE.
+
+
+### Sibling plugins
+There may be a circumstance where you'd like to make use of another plugin from within your own plugin. For example, if you wanted to wrap the core `search` method in your own `my_search` function. This can be done by defining a *plugin dependency*.
+
+This is very simple to do, just place a definition of the plugin you'd like to use within your own plugin definition. Here's an example that illustrates the situation metioned above
+
+```python
+from rgd_client.plugin import CorePlugin
+
+
+class MyPlugin(RgdPlugin):
+    rgd = CorePlugin
+
+    def my_search(self, *args, **kwargs):
+        res = self.rgd.search(*args, **kwargs)
+
+        print('Search Performed!')
+        return res
+
+class MyClient:
+    foo = MyPlugin
+
+```
+
+When `create_rgd_client` is called, it searches all registered plugins for members that inherit `RgdPlugin`, and instantiates them if it does. So, as long as the plugin you want to use is installed with `pip`, or is provided in `extra_plugins`, it will be injected into your plugin.

--- a/django-rgd/client/rgd_client/_plugin_utils.py
+++ b/django-rgd/client/rgd_client/_plugin_utils.py
@@ -1,0 +1,65 @@
+import inspect
+from typing import Dict, List, Optional, Type
+
+from pkg_resources import iter_entry_points
+from rgd_client.client import RgdClient
+
+from rgd_client.plugin import CorePlugin, RGDPlugin
+from rgd_client.session import clone_session
+
+
+_NAMESPACE = 'rgd_client.plugin'
+_PLUGIN_CLASS_DICT = Dict[str, Type[RGDPlugin]]
+_PLUGIN_INSTANCE_DICT = Dict[Type[RGDPlugin], RGDPlugin]
+
+
+def _plugin_classes(extra_plugins: Optional[List] = None) -> _PLUGIN_CLASS_DICT:
+    """Return a dict that maps a plugin namespace to its class."""
+    entry_points = iter_entry_points(_NAMESPACE)
+    plugins_classes = [ep.load() for ep in entry_points]
+    if extra_plugins is not None:
+        plugins_classes.extend(extra_plugins)
+
+    members = {}
+    for cls in plugins_classes:
+        members.update(
+            {
+                n: v
+                for n, v in inspect.getmembers(cls)
+                if inspect.isclass(v) and issubclass(v, RGDPlugin)
+            }
+        )
+
+    return members
+
+
+def _plugin_instances(
+    client: RgdClient, plugin_classes: _PLUGIN_CLASS_DICT
+) -> _PLUGIN_INSTANCE_DICT:
+    """Return a dict that maps a plugin class to its instance."""
+    instance_dict: _PLUGIN_INSTANCE_DICT = {CorePlugin: client.rgd}
+    for name, cls in plugin_classes.items():
+        instance = cls(clone_session(client.session))
+        setattr(client, name, instance)
+        instance_dict[cls] = instance
+
+    return instance_dict
+
+
+def _inject_plugin_deps(plugin_instances: _PLUGIN_INSTANCE_DICT):
+    """Inject plugin dependencies for each plugin instance."""
+    for plugin_class, plugin_instance in plugin_instances.items():
+        # Ensure plugins class is defined
+        if not inspect.isclass(getattr(plugin_class, 'plugins', None)):
+            continue
+
+        # Retrieve deps
+        deps = [
+            (name, val)
+            for name, val in inspect.getmembers(plugin_class.plugins)
+            if inspect.isclass(val) and issubclass(val, RGDPlugin)
+        ]
+
+        for name, cls in deps:
+            if cls in plugin_instances:
+                setattr(plugin_instance.plugins, name, plugin_instances[cls])

--- a/django-rgd/client/rgd_client/_plugin_utils.py
+++ b/django-rgd/client/rgd_client/_plugin_utils.py
@@ -4,13 +4,13 @@ from typing import Dict, List, Optional, Type
 from pkg_resources import iter_entry_points
 from rgd_client.client import RgdClient
 
-from rgd_client.plugin import CorePlugin, RGDPlugin
+from rgd_client.plugin import CorePlugin, RgdPlugin
 from rgd_client.session import clone_session
 
 
 _NAMESPACE = 'rgd_client.plugin'
-_PLUGIN_CLASS_DICT = Dict[str, Type[RGDPlugin]]
-_PLUGIN_INSTANCE_DICT = Dict[Type[RGDPlugin], RGDPlugin]
+_PLUGIN_CLASS_DICT = Dict[str, Type[RgdPlugin]]
+_PLUGIN_INSTANCE_DICT = Dict[Type[RgdPlugin], RgdPlugin]
 
 
 def _plugin_classes(extra_plugins: Optional[List] = None) -> _PLUGIN_CLASS_DICT:
@@ -26,7 +26,7 @@ def _plugin_classes(extra_plugins: Optional[List] = None) -> _PLUGIN_CLASS_DICT:
             {
                 n: v
                 for n, v in inspect.getmembers(cls)
-                if inspect.isclass(v) and issubclass(v, RGDPlugin)
+                if inspect.isclass(v) and issubclass(v, RgdPlugin)
             }
         )
 
@@ -52,7 +52,7 @@ def _inject_plugin_deps(plugin_instances: _PLUGIN_INSTANCE_DICT):
         deps = [
             (name, val)
             for name, val in inspect.getmembers(plugin_class)
-            if inspect.isclass(val) and issubclass(val, RGDPlugin)
+            if inspect.isclass(val) and issubclass(val, RgdPlugin)
         ]
 
         for name, cls in deps:

--- a/django-rgd/client/rgd_client/_plugin_utils.py
+++ b/django-rgd/client/rgd_client/_plugin_utils.py
@@ -3,10 +3,8 @@ from typing import Dict, List, Optional, Type
 
 from pkg_resources import iter_entry_points
 from rgd_client.client import RgdClient
-
 from rgd_client.plugin import CorePlugin, RgdPlugin
 from rgd_client.session import clone_session
-
 
 _NAMESPACE = 'rgd_client.plugin'
 _PLUGIN_CLASS_DICT = Dict[str, Type[RgdPlugin]]

--- a/django-rgd/client/rgd_client/_plugin_utils.py
+++ b/django-rgd/client/rgd_client/_plugin_utils.py
@@ -49,17 +49,12 @@ def _plugin_instances(
 def _inject_plugin_deps(plugin_instances: _PLUGIN_INSTANCE_DICT):
     """Inject plugin dependencies for each plugin instance."""
     for plugin_class, plugin_instance in plugin_instances.items():
-        # Ensure plugins class is defined
-        if not inspect.isclass(getattr(plugin_class, 'plugins', None)):
-            continue
-
-        # Retrieve deps
         deps = [
             (name, val)
-            for name, val in inspect.getmembers(plugin_class.plugins)
+            for name, val in inspect.getmembers(plugin_class)
             if inspect.isclass(val) and issubclass(val, RGDPlugin)
         ]
 
         for name, cls in deps:
             if cls in plugin_instances:
-                setattr(plugin_instance.plugins, name, plugin_instances[cls])
+                setattr(plugin_instance, name, plugin_instances[cls])

--- a/django-rgd/client/rgd_client/client.py
+++ b/django-rgd/client/rgd_client/client.py
@@ -88,7 +88,7 @@ def create_rgd_client(
     extra_plugins: Optional[List[Type]] = None,
 ):
     # Avoid circular import
-    from ._plugin_utils import _plugin_classes, _plugin_instances, _inject_plugin_deps
+    from ._plugin_utils import _inject_plugin_deps, _plugin_classes, _plugin_instances
 
     # Create initial client
     client = RgdClient(api_url, username, password, save)

--- a/django-rgd/client/rgd_client/client.py
+++ b/django-rgd/client/rgd_client/client.py
@@ -1,18 +1,12 @@
 import getpass
-import inspect
 import os
-from typing import Dict, List, Optional, Type
+from typing import List, Optional, Type
 
-from pkg_resources import iter_entry_points
 import requests
 
-from .plugin import CorePlugin, RGDPlugin
+from .plugin import CorePlugin
 from .session import RgdClientSession, clone_session
 from .utils import API_KEY_DIR_PATH, API_KEY_FILE_NAME, DEFAULT_RGD_API
-
-_NAMESPACE = 'rgd_client.plugin'
-_PLUGIN_CLASS_DICT = Dict[str, Type[RGDPlugin]]
-_PLUGIN_INSTANCE_DICT = Dict[Type[RGDPlugin], RGDPlugin]
 
 
 class RgdClient:
@@ -55,58 +49,6 @@ class RgdClient:
         (API_KEY_DIR_PATH / API_KEY_FILE_NAME).unlink(missing_ok=True)
 
 
-def _plugin_classes(extra_plugins: Optional[List] = None) -> _PLUGIN_CLASS_DICT:
-    """Return a dict that maps a plugin namespace to its class."""
-    entry_points = iter_entry_points(_NAMESPACE)
-    plugins_classes = [ep.load() for ep in entry_points]
-    if extra_plugins is not None:
-        plugins_classes.extend(extra_plugins)
-
-    members = {}
-    for cls in plugins_classes:
-        members.update(
-            {
-                n: v
-                for n, v in inspect.getmembers(cls)
-                if inspect.isclass(v) and issubclass(v, RGDPlugin)
-            }
-        )
-
-    return members
-
-
-def _plugin_instances(
-    client: RgdClient, plugin_classes: _PLUGIN_CLASS_DICT
-) -> _PLUGIN_INSTANCE_DICT:
-    """Return a dict that maps a plugin class to its instance."""
-    instance_dict: _PLUGIN_INSTANCE_DICT = {CorePlugin: client.rgd}
-    for name, cls in plugin_classes.items():
-        instance = cls(clone_session(client.session))
-        setattr(client, name, instance)
-        instance_dict[cls] = instance
-
-    return instance_dict
-
-
-def _inject_plugin_deps(plugin_instances: _PLUGIN_INSTANCE_DICT):
-    """Inject plugin dependencies for each plugin instance."""
-    for plugin_class, plugin_instance in plugin_instances.items():
-        # Ensure plugins class is defined
-        if not inspect.isclass(getattr(plugin_class, 'plugins', None)):
-            continue
-
-        # Retrieve deps
-        deps = [
-            (name, val)
-            for name, val in inspect.getmembers(plugin_class.plugins)
-            if inspect.isclass(val) and issubclass(val, RGDPlugin)
-        ]
-
-        for name, cls in deps:
-            if cls in plugin_instances:
-                setattr(plugin_instance.plugins, name, plugin_instances[cls])
-
-
 def _get_api_key(api_url: str, username: str, password: str, save: bool) -> str:
     """Get an RGD API Key for the given user from the server, and save it if requested."""
     resp = requests.post(f'{api_url}/api-token-auth', {'username': username, 'password': password})
@@ -145,6 +87,9 @@ def create_rgd_client(
     save: Optional[bool] = True,
     extra_plugins: Optional[List[Type]] = None,
 ):
+    # Avoid circular import
+    from ._plugin_utils import _plugin_classes, _plugin_instances, _inject_plugin_deps
+
     # Create initial client
     client = RgdClient(api_url, username, password, save)
 

--- a/django-rgd/client/rgd_client/plugin.py
+++ b/django-rgd/client/rgd_client/plugin.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import validators
 
@@ -8,8 +8,6 @@ from .utils import spatial_search_params
 
 
 class RGDPlugin:
-    plugins: Optional[Type] = None
-
     def __init__(self, session: RgdClientSession):
         self.session = session
 

--- a/django-rgd/client/rgd_client/plugin.py
+++ b/django-rgd/client/rgd_client/plugin.py
@@ -7,12 +7,14 @@ from .types import DATETIME_OR_STR_TUPLE, SEARCH_PREDICATE_CHOICE
 from .utils import spatial_search_params
 
 
-class RGDPlugin:
+class RgdPlugin:
+    """The base plugin that all other plugins must inherit from."""
+
     def __init__(self, session: RgdClientSession):
         self.session = session
 
 
-class CorePlugin(RGDPlugin):
+class CorePlugin(RgdPlugin):
     """The core django-rgd client plugin."""
 
     def __init__(self, *args, **kwargs):

--- a/django-rgd/client/rgd_client/plugin.py
+++ b/django-rgd/client/rgd_client/plugin.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 import validators
 
@@ -7,11 +7,18 @@ from .types import DATETIME_OR_STR_TUPLE, SEARCH_PREDICATE_CHOICE
 from .utils import spatial_search_params
 
 
-class CorePlugin:
-    """The core django-rgd client plugin."""
+class RGDPlugin:
+    plugins: Optional[Type] = None
 
     def __init__(self, session: RgdClientSession):
         self.session = session
+
+
+class CorePlugin(RGDPlugin):
+    """The core django-rgd client plugin."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.session.base_url += 'rgd/'
 
     def search(

--- a/django-rgd/tests/test_client_plugins.py
+++ b/django-rgd/tests/test_client_plugins.py
@@ -32,3 +32,8 @@ def test_plugin_dependency_inject():
     assert isinstance(client.a.rgd, CorePlugin)
     assert isinstance(client.b.rgd, CorePlugin)
     assert isinstance(client.b.a, PluginA)
+
+    # Assert underlying class is not modified
+    assert not isinstance(PluginA.rgd, CorePlugin)
+    assert not isinstance(PluginB.rgd, CorePlugin)
+    assert not isinstance(PluginB.a, PluginA)

--- a/django-rgd/tests/test_client_plugins.py
+++ b/django-rgd/tests/test_client_plugins.py
@@ -1,0 +1,42 @@
+from rgd_client import create_rgd_client
+from rgd_client.plugin import CorePlugin, RGDPlugin
+
+
+# Plugin A
+class PluginADependencies:
+    rgd = CorePlugin
+
+
+class PluginA(RGDPlugin):
+    plugins = PluginADependencies
+
+
+class ClientA:
+    a = PluginA
+
+
+# Plugin B
+class PluginBDependencies:
+    a = PluginA
+    rgd = CorePlugin
+
+
+class PluginB(RGDPlugin):
+    plugins = PluginBDependencies
+
+
+class ClientB:
+    b = PluginB
+
+
+class MyClient(ClientA, ClientB):
+    pass
+
+
+def test_plugin_dependency_inject():
+    client: MyClient = create_rgd_client(extra_plugins=[ClientA, ClientB])
+
+    # Assert plugins were loaded correctly
+    assert isinstance(client.a.plugins.rgd, CorePlugin)
+    assert isinstance(client.b.plugins.rgd, CorePlugin)
+    assert isinstance(client.b.plugins.a, PluginA)

--- a/django-rgd/tests/test_client_plugins.py
+++ b/django-rgd/tests/test_client_plugins.py
@@ -3,12 +3,8 @@ from rgd_client.plugin import CorePlugin, RGDPlugin
 
 
 # Plugin A
-class PluginADependencies:
-    rgd = CorePlugin
-
-
 class PluginA(RGDPlugin):
-    plugins = PluginADependencies
+    rgd = CorePlugin
 
 
 class ClientA:
@@ -16,13 +12,9 @@ class ClientA:
 
 
 # Plugin B
-class PluginBDependencies:
+class PluginB(RGDPlugin):
     a = PluginA
     rgd = CorePlugin
-
-
-class PluginB(RGDPlugin):
-    plugins = PluginBDependencies
 
 
 class ClientB:
@@ -37,6 +29,6 @@ def test_plugin_dependency_inject():
     client: MyClient = create_rgd_client(extra_plugins=[ClientA, ClientB])
 
     # Assert plugins were loaded correctly
-    assert isinstance(client.a.plugins.rgd, CorePlugin)
-    assert isinstance(client.b.plugins.rgd, CorePlugin)
-    assert isinstance(client.b.plugins.a, PluginA)
+    assert isinstance(client.a.rgd, CorePlugin)
+    assert isinstance(client.b.rgd, CorePlugin)
+    assert isinstance(client.b.a, PluginA)

--- a/django-rgd/tests/test_client_plugins.py
+++ b/django-rgd/tests/test_client_plugins.py
@@ -1,9 +1,9 @@
 from rgd_client import create_rgd_client
-from rgd_client.plugin import CorePlugin, RGDPlugin
+from rgd_client.plugin import CorePlugin, RgdPlugin
 
 
 # Plugin A
-class PluginA(RGDPlugin):
+class PluginA(RgdPlugin):
     rgd = CorePlugin
 
 
@@ -12,7 +12,7 @@ class ClientA:
 
 
 # Plugin B
-class PluginB(RGDPlugin):
+class PluginB(RgdPlugin):
     a = PluginA
     rgd = CorePlugin
 


### PR DESCRIPTION
Closes #564 

This PR allows for a plugin to access a sibling plugin by defining a _plugin dependency_. In this context, a "sibling plugin" is just any plugin that's installed alongside the plugin in question. While access to all namespaced plugins was already available from the _client_, prior to this change, plugins themselves could not see other plugins.

This has the following breaking change: Plugins must now inherit from `RgdPlugin`. This both helps with plugin discovery, as well as allows for plugin dependencies to be defined.

I'm fairly happy with this solution, but please take a look and lmk if you think this approach is flawed in some way, or if you think there's a better approach.
