### PR TITLE
Add tree action on ChecksumFile ViewSet

### DIFF
--- a/django-rgd/rgd/models/file.py
+++ b/django-rgd/rgd/models/file.py
@@ -103,6 +103,10 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
     def basename(self):
         return os.path.basename(self.name)
 
+    @property
+    def size(self):
+        return self.file.size
+
     def get_checksum(self):
         """Compute a new checksum without saving it."""
         if self.type == FileSourceType.FILE_FIELD:

--- a/django-rgd/rgd/models/file.py
+++ b/django-rgd/rgd/models/file.py
@@ -105,7 +105,11 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
 
     @property
     def size(self):
-        return self.file.size
+        # Ensure safe check of self.file
+        try:
+            return self.file.size
+        except ValueError:
+            return None
 
     def get_checksum(self):
         """Compute a new checksum without saving it."""

--- a/django-rgd/rgd/rest/viewsets.py
+++ b/django-rgd/rgd/rest/viewsets.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponseRedirect
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
+from rest_framework.response import Response
 from rgd import models, serializers
 from rgd.filters import SpatialEntryFilter
 from rgd.rest.base import ModelViewSet, ReadOnlyModelViewSet
@@ -28,6 +29,55 @@ class ChecksumFileViewSet(ModelViewSet):
     def data(self, request, pk=None):
         obj = self.get_object()
         return HttpResponseRedirect(obj.get_url())
+
+    @swagger_auto_schema(
+        query_serializer=serializers.ChecksumFilePathQuerySerializer(),
+        responses={200: serializers.ChecksumFilePathsSerializer()},
+    )
+    @action(detail=False, methods=['GET'])
+    def tree(self, request, **kwargs):
+        """
+        View all ChecksumFiles in a native folder/file structure, specifying folder/file name with path_prefix.
+        """
+        path_prefix: str = self.request.query_params.get('path_prefix') or ''
+        qs = self.get_queryset().filter(name__startswith=path_prefix)
+
+        folders: dict[str, dict] = {}
+        files: dict[str, models.ChecksumFile] = {}
+
+        for file in qs:
+            file: models.ChecksumFile
+
+            # Get the remainder of the path after path_prefix
+            base_path: str = file.name[len(path_prefix) :].strip('/')
+
+            # Since we stripped slashes, any remaining slashes indicate a folder
+            folder_index = base_path.find('/')
+            is_folder = folder_index >= 0
+
+            if not is_folder:
+                # Ensure base_path is entire filename
+                base_path = file.name[file.name.rfind('/') + 1 :]
+                files[base_path] = file
+            else:
+                base_path = base_path[:folder_index]
+                entry = folders.get(base_path)
+                if entry is None:
+                    folders[base_path] = {
+                        'size': file.size,
+                        'num_files': 1,
+                        'created': file.created,
+                        'modified': file.modified,
+                    }
+                else:
+                    entry['size'] += file.size
+                    entry['num_files'] += 1
+                    entry['created'] = min(entry['created'], file.created)  # earliest
+                    entry['modified'] = max(entry['modified'], file.modified)  # latest
+
+        return Response(
+            serializers.ChecksumFilePathsSerializer({'folders': folders, 'files': files}).data
+        )
 
 
 class SpatialEntryViewSet(ReadOnlyModelViewSet):

--- a/django-rgd/rgd/rest/viewsets.py
+++ b/django-rgd/rgd/rest/viewsets.py
@@ -36,9 +36,7 @@ class ChecksumFileViewSet(ModelViewSet):
     )
     @action(detail=False, methods=['GET'])
     def tree(self, request, **kwargs):
-        """
-        View all ChecksumFiles in a native folder/file structure, specifying folder/file name with path_prefix.
-        """
+        """View ChecksumFiles in a hierarchy, specifying folder/file name with path_prefix."""
         path_prefix: str = self.request.query_params.get('path_prefix') or ''
         qs = self.get_queryset().filter(name__startswith=path_prefix)
 

--- a/django-rgd/rgd/rest/viewsets.py
+++ b/django-rgd/rgd/rest/viewsets.py
@@ -60,16 +60,24 @@ class ChecksumFileViewSet(ModelViewSet):
             else:
                 base_path = base_path[:folder_index]
                 entry = folders.get(base_path)
+                fixed_file_size = file.size or 0
+                url_file_as_int = 1 - int(bool(file.size))
+
+                # Either create new folder entry, or add to existing folder
                 if entry is None:
+                    # New folder entry
                     folders[base_path] = {
-                        'size': file.size,
+                        'known_size': fixed_file_size,
                         'num_files': 1,
+                        'num_url_files': url_file_as_int,
                         'created': file.created,
                         'modified': file.modified,
                     }
                 else:
-                    entry['size'] += file.size
+                    # Add to existing folder
+                    entry['known_size'] += fixed_file_size
                     entry['num_files'] += 1
+                    entry['num_url_files'] += url_file_as_int
                     entry['created'] = min(entry['created'], file.created)  # earliest
                     entry['modified'] = max(entry['modified'], file.modified)  # latest
 

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -48,8 +48,9 @@ class CollectionPermissionSerializer(serializers.ModelSerializer):
 
 
 class ChecksumFileFolderSerializer(serializers.Serializer):
-    size = serializers.IntegerField()
+    known_size = serializers.IntegerField()
     num_files = serializers.IntegerField()
+    num_url_files = serializers.IntegerField()
     created = serializers.DateTimeField()
     modified = serializers.DateTimeField()
 

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -47,6 +47,13 @@ class CollectionPermissionSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class ChecksumFileFolderSerializer(serializers.Serializer):
+    size = serializers.IntegerField()
+    num_files = serializers.IntegerField()
+    created = serializers.DateTimeField()
+    modified = serializers.DateTimeField()
+
+
 class ChecksumFileSerializer(serializers.ModelSerializer):
     """Serializer for ChecksumFiles.
 
@@ -69,6 +76,15 @@ class ChecksumFileSerializer(serializers.ModelSerializer):
             + MODIFIABLE_READ_ONLY_FIELDS
             + TASK_EVENT_READ_ONLY_FIELDS
         )
+
+
+class ChecksumFilePathQuerySerializer(serializers.Serializer):
+    path_prefix = serializers.CharField(required=False)
+
+
+class ChecksumFilePathsSerializer(serializers.Serializer):
+    folders = serializers.DictField(child=ChecksumFileFolderSerializer())
+    files = serializers.DictField(child=ChecksumFileSerializer())
 
 
 class SpatialEntrySerializer(serializers.ModelSerializer):

--- a/django-rgd/tests/test_rest.py
+++ b/django-rgd/tests/test_rest.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import pytest
 from rest_framework import status
+from rgd.models import ChecksumFile
 
 
 @pytest.mark.django_db(transaction=True)
@@ -45,3 +48,78 @@ def test_get_spatial_entry(admin_api_client, spatial_asset_a):
     assert response.status_code == 200
     assert response.data
     assert response.data['outline']
+
+
+@pytest.mark.django_db(transaction=True)
+def test_get_checksum_file_tree(
+    checksum_file_factory, checksum_file_url: ChecksumFile, admin_api_client
+):
+    """Test that the tree list endpoint functions as expected."""
+    # Top level
+    file1: ChecksumFile = checksum_file_factory(name='h.txt')
+
+    # a/ directory
+    file2: ChecksumFile = checksum_file_factory(name='a/f.txt')
+    file3: ChecksumFile = checksum_file_factory(name='a/g.txt')
+
+    # a/b/ directory
+    file4: ChecksumFile = checksum_file_factory(name='a/b/d.txt')
+    file5: ChecksumFile = checksum_file_factory(name='a/b/e.txt')
+
+    # Put one url file in a/b/ directory
+    checksum_file_url.name = 'a/b/c.jpg'
+    checksum_file_url.save()
+    file6 = checksum_file_url
+
+    # Testing folders
+    folder_b = [file4, file5, file6]
+    folder_a = [file2, file3] + folder_b
+
+    known_size_a = sum([f.size for f in folder_a if f.size is not None])
+    a_created = min([file.created for file in folder_a]).isoformat()
+    a_modified = max([file.modified for file in folder_a]).isoformat()
+
+    known_size_b = sum([f.size for f in folder_b if f.size is not None])
+    b_created = min([file.created for file in folder_b]).isoformat()
+    b_modified = max([file.modified for file in folder_b]).isoformat()
+
+    # Check top level response
+    r = admin_api_client.get('/api/rgd/checksum_file/tree')
+    assert r.json()['files'][file1.name]['id'] == file1.id
+    assert r.json()['folders'] == {
+        'a': {
+            'known_size': known_size_a,
+            'num_files': len(folder_a),
+            'num_url_files': 1,
+            'created': a_created,
+            'modified': a_modified,
+        }
+    }
+
+    # Search folder 'a'
+    r = admin_api_client.get('/api/rgd/checksum_file/tree', {'path_prefix': 'a'})
+
+    # Files
+    files = r.json()['files']
+    assert files[Path(file2.name).name]['id'] == file2.id
+    assert files[Path(file3.name).name]['id'] == file3.id
+
+    # Folders
+    assert r.json()['folders'] == {
+        'b': {
+            'known_size': known_size_b,
+            'num_files': len(folder_b),
+            'num_url_files': 1,
+            'created': b_created,
+            'modified': b_modified,
+        }
+    }
+
+    # Search folder 'a/b'
+    r = admin_api_client.get('/api/rgd/checksum_file/tree', {'path_prefix': 'a/b'})
+
+    # Files
+    files = r.json()['files']
+    assert files[Path(file4.name).name]['id'] == file4.id
+    assert files[Path(file5.name).name]['id'] == file5.id
+    assert files[Path(file6.name).name]['id'] == file6.id

--- a/testing-utils/rgd_testing_utils/factories.py
+++ b/testing-utils/rgd_testing_utils/factories.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import User
 import factory
 import factory.django
 from rgd import models
+from rgd.datastore import datastore
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -18,7 +19,7 @@ class ChecksumFileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.ChecksumFile
 
-    file = factory.django.FileField(filename='sample.dat')
+    file = factory.django.FileField(from_path=datastore.fetch('stars.png'))
 
     # If we have an on_commit or post_save method that modifies the model, we
     # need to refresh it afterwards.


### PR DESCRIPTION
This PR adds a `tree` action, which allows for files to be searched by their name prefix. The result serves to mimic a normal folder hierarchy, returning files/folders at each level. For example, if you had the following files injested:

* `folder/a.txt`
* `folder/b.txt`
* `folder/c/d.txt`

These can be viewed as such

```
folder/
| -- a.txt
| -- b.txt
| -- c/
|    | -- d.txt
```

If you wanted to search for all files under `folder`, you would just pass `folder` to the `tree` endpoint in `path_prefix`. The result would be roughly the following

```
"folders": {
  "c": {
    "size": 123123,
    "num_files": 1,
    "created": "2021-11-05T21:23:41.498195Z",
    "modified": "2021-11-05T21:23:41.498210Z"
  }
},
"files": {
  "a.txt": <ChecksumFile>,
  "b.txt": <ChecksumFile>
}
```

And extending the path_prefix to `folder/c` would yield the final file `d.txt`.