### PR TITLE
Place FileLocks under dedicated path

### DIFF
--- a/django-rgd/rgd/models/file.py
+++ b/django-rgd/rgd/models/file.py
@@ -9,7 +9,6 @@ from crum import get_current_user
 from django.conf import settings
 from django.contrib.gis.db import models
 from django_extensions.db.models import TimeStampedModel
-from filelock import FileLock
 from rgd.utility import (
     _link_url,
     clean_file_cache,

--- a/django-rgd/rgd/models/file.py
+++ b/django-rgd/rgd/models/file.py
@@ -19,6 +19,7 @@ from rgd.utility import (
     download_field_file_to_local_path,
     download_url_file_to_local_path,
     get_cache_dir,
+    get_file_lock,
     patch_internal_presign,
     precheck_fuse,
     safe_urlopen,
@@ -197,9 +198,7 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
             dest_path = Path(directory, self.name)
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         # Thread/process safe locking for file access
-        lock = FileLock(
-            f'{dest_path}.lock'
-        )  # timeout=getattr(settings, 'RGD_FILE_LOCK_TIMEOUT', 10000))
+        lock = get_file_lock(dest_path)
 
         with lock:  # TODO: handle timeouts in condition
             if dest_path.exists() and dest_path.stat().st_size > 0:
@@ -274,7 +273,7 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin, PermissionPathMixin):
         # Not in file_set. Download to cache dir
         path = self.download_to_local_path()
         # provide a lock on this file while yielding
-        lock = FileLock(f'{path}.lock')
+        lock = get_file_lock(path)
         with lock:
             yield path
 

--- a/django-rgd/rgd/models/utils.py
+++ b/django-rgd/rgd/models/utils.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
-from filelock import FileLock
 
 from ..utility import compute_checksum_url, compute_hash, get_file_lock, get_or_create_no_commit
 from .collection import Collection

--- a/django-rgd/rgd/models/utils.py
+++ b/django-rgd/rgd/models/utils.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
 from filelock import FileLock
 
-from ..utility import compute_checksum_url, compute_hash, get_or_create_no_commit
+from ..utility import compute_checksum_url, compute_hash, get_file_lock, get_or_create_no_commit
 from .collection import Collection
 from .file import ChecksumFile, FileSourceType
 from .mixins import Status
@@ -139,8 +139,7 @@ def yield_checksumfiles(queryset: Union[QuerySet, List[ChecksumFile]], directory
     directory = Path(directory)
     directory.touch()
     # Acquire a lock on the directory so that it isn't cleaned up
-    lock_file_path = f'{directory}.lock'
-    lock = FileLock(lock_file_path)
+    lock = get_file_lock(directory)
     lock.acquire()
     # Download each file to the directory and yeild it so that the lock can be released when done
     try:

--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -51,10 +51,11 @@ def get_lock_dir():
     return path
 
 
-def get_file_lock(path):
+def get_file_lock(path: Path):
     """Create a file lock under the lock directory."""
-    hash = hashlib.sha512(str(path).encode('utf-8')).hexdigest()
-    lock_path = Path(get_lock_dir(), f'{hash}.lock')
+    # Computes the hash using Pathlib's hash implementation on absolute path
+    sha = hash(path.absolute())
+    lock_path = Path(get_lock_dir(), f'{sha}.lock')
     lock = FileLock(lock_path)
     return lock
 

--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -294,9 +294,7 @@ def clean_file_cache(override_target=None):
     """
     cache = get_cache_dir()
     # Sort each directory by mtime
-    paths = sorted(
-        [f for f in Path(cache).iterdir()], key=os.path.getmtime
-    )  # This sorts oldest to latest
+    paths = sorted(Path(cache).iterdir(), key=os.path.getmtime)  # This sorts oldest to latest
     # While free space is not enough, remove directories until all ar gone
     initial = psutil.disk_usage(cache).free
     target = override_target or getattr(settings, 'RGD_TARGET_AVAILABLE_CACHE', 2)


### PR DESCRIPTION
Resolve #555 

This creates a new temporary directory called `file_locks` where we store all file locks to avoid any issues with downstream software not wanting/needing those lock files. After all, these files should only be used by RGD.

To do this, I am taking the hash of the checked-out file path and saving that hash as the lock file under the temporary directory. 