### PR TITLE
Retrieve new API key if the saved key is invalid

### DIFF
--- a/django-rgd/client/rgd_client/client.py
+++ b/django-rgd/client/rgd_client/client.py
@@ -102,6 +102,7 @@ def _read_api_key(api_url: str, username: str = None, password: str = None) -> O
             return api_key
         else:
             logger.error('Provide your username and password next time to fetch a new one.')
+            return None
 
     return api_key
 

--- a/django-rgd/client/rgd_client/client.py
+++ b/django-rgd/client/rgd_client/client.py
@@ -56,7 +56,7 @@ class RgdClient:
         (API_KEY_DIR_PATH / API_KEY_FILE_NAME).unlink(missing_ok=True)
 
 
-def _get_api_key(api_url: str, username: str, password: str, save: bool) -> str:
+def _get_api_key(api_url: str, username: str, password: str, save: bool) -> Optional[str]:
     """Get an RGD API Key for the given user from the server, and save it if requested."""
     resp = requests.post(f'{api_url}/api-token-auth', {'username': username, 'password': password})
     token = resp.json().get('token')

--- a/django-rgd/tests/conftest.py
+++ b/django-rgd/tests/conftest.py
@@ -34,7 +34,6 @@ def py_client(live_server):
 
 @pytest.fixture
 def user_with_api_key(faker):
-    """A user with an associated API key."""
     email = faker.email()
     password = 'password'
     params = {'username': email, 'email': email, 'password': password}

--- a/django-rgd/tests/conftest.py
+++ b/django-rgd/tests/conftest.py
@@ -30,3 +30,19 @@ def py_client(live_server):
     )
 
     return client
+
+
+@pytest.fixture
+def user_with_api_key(faker):
+    """A user with an associated API key."""
+    email = faker.email()
+    password = 'password'
+    params = {'username': email, 'email': email, 'password': password}
+
+    user = User.objects.create_user(is_staff=True, is_superuser=True, **params)
+    user.save()
+
+    api_token = 'topsecretkey'
+    Token.objects.create(user=user, key=api_token)
+
+    return email, password, api_token

--- a/django-rgd/tests/test_client.py
+++ b/django-rgd/tests/test_client.py
@@ -36,19 +36,13 @@ def test_create_file_from_url(py_client: RgdClient, checksum_file_url: ChecksumF
 
 
 @pytest.mark.django_db(transaction=True)
-def test_save_api_key(live_server, faker):
+def test_save_api_key(live_server, user_with_api_key):
     """Test that saving an API key works correctly."""
-    # Create a fake user just for this test
-    email = faker.email()
-    params = {'username': email, 'email': email, 'password': 'password'}
-    user = User.objects.create_user(is_staff=True, is_superuser=True, **params)
-    user.save()
-    api_token = 'topsecretkey'
-    Token.objects.create(user=user, key=api_token)
+    username, password, api_token = user_with_api_key
 
     create_rgd_client(
-        username=params['username'],
-        password=params['password'],
+        username=username,
+        password=password,
         api_url=f'{live_server.url}/api',
         save=True,  # save the API key
     )

--- a/django-rgd/tests/test_client.py
+++ b/django-rgd/tests/test_client.py
@@ -1,8 +1,6 @@
 import json
 
-from django.contrib.auth.models import User
 import pytest
-from rest_framework.authtoken.models import Token
 from rgd.models import ChecksumFile
 from rgd_client import RgdClient, create_rgd_client
 from rgd_client.utils import API_KEY_DIR_PATH, API_KEY_FILE_NAME


### PR DESCRIPTION
When using an API key from `~/.rgd/token`, the client will verify the key is valid by calling a protected endpoint. If it's not, and the user also provided their username and password, the client will attempt to retrieve a new API key from the server and save it at `~/.rgd/token`.

This PR also adds a test for the new functionality and logging to clarify what's going on when an API key is invalid.

Closes #563 