### PR TITLE
Extract ROIs from Raster detail view

### DIFF
--- a/django-rgd-imagery/rgd_imagery/large_image_utilities.py
+++ b/django-rgd-imagery/rgd_imagery/large_image_utilities.py
@@ -1,5 +1,4 @@
 from contextlib import contextmanager
-import logging
 import os
 import pathlib
 import tempfile
@@ -9,8 +8,6 @@ from large_image.tilesource import FileTileSource
 from large_image_source_gdal import GDALFileTileSource
 from rgd.utility import get_cache_dir
 from rgd_imagery.models import Image
-
-logger = logging.getLogger(__name__)
 
 
 def get_tilesource_from_image(

--- a/django-rgd-imagery/rgd_imagery/large_image_utilities.py
+++ b/django-rgd-imagery/rgd_imagery/large_image_utilities.py
@@ -81,7 +81,7 @@ def get_tile_bounds(
     tile_source: FileTileSource,
     projection: str = 'EPSG:4326',
 ):
-    bounds = tile_source.getBounds(srs='EPSG:4326')
+    bounds = tile_source.getBounds(srs=projection)
     threshold = 89.9999
     for key in ('ymin', 'ymax'):
         bounds[key] = max(min(bounds[key], threshold), -threshold)

--- a/django-rgd-imagery/rgd_imagery/large_image_utilities.py
+++ b/django-rgd-imagery/rgd_imagery/large_image_utilities.py
@@ -28,9 +28,9 @@ def get_region_world(
     right: float,
     bottom: float,
     top: float,
-    projection: str = 'EPSG:4326',
+    units: str = 'EPSG:4326',
 ):
-    region = dict(left=left, right=right, bottom=bottom, top=top, units=projection)
+    region = dict(left=left, right=right, bottom=bottom, top=top, units=units)
     path, mime_type = tile_source.getRegion(region=region, encoding='TILED')
     return path, mime_type
 

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -152,7 +152,7 @@ class TileRegionPixelView(BaseTileView):
             right,
             bottom,
             top,
-            encoding,
+            encoding=encoding,
         )
         tile_binary = open(path, 'rb')
         return HttpResponse(tile_binary, content_type=mime_type)

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -21,7 +21,14 @@ class BaseTileView(BaseRestViewMixin, APIView):
         band = int(request.query_params.get('band', 0))
         style = None
         if band:
-            style = json.dumps({'band': band})
+            style = {'band': band}
+            bmin = request.query_params.get('min', None)
+            bmax = request.query_params.get('max', None)
+            if bmin is not None:
+                style['min'] = bmin
+            if bmax is not None:
+                style['max'] = bmax
+            style = json.dumps(style)
         return large_image_utilities.get_tilesource_from_image(image_entry, projection, style=style)
 
 

--- a/django-rgd-imagery/rgd_imagery/rest/tiles.py
+++ b/django-rgd-imagery/rgd_imagery/rest/tiles.py
@@ -121,8 +121,15 @@ class TileRegionView(BaseTileView):
         if not isinstance(tile_source, GDALFileTileSource):
             raise TypeError('Souce image must have geospatial reference.')
         units = request.query_params.get('units', 'EPSG:4326')
+        encoding = request.query_params.get('encoding', 'TILED')
         path, mime_type = large_image_utilities.get_region_world(
-            tile_source, left, right, bottom, top, units
+            tile_source,
+            left,
+            right,
+            bottom,
+            top,
+            units,
+            encoding,
         )
         if not path:
             # TODO: should this raise error status?
@@ -138,8 +145,14 @@ class TileRegionPixelView(BaseTileView):
         self, request: Request, pk: int, left: float, right: float, bottom: float, top: float
     ) -> HttpResponse:
         tile_source = self.get_tile_source(request, pk)
+        encoding = request.query_params.get('encoding', None)
         path, mime_type = large_image_utilities.get_region_pixel(
-            tile_source, left, right, bottom, top
+            tile_source,
+            left,
+            right,
+            bottom,
+            top,
+            encoding,
         )
         tile_binary = open(path, 'rb')
         return HttpResponse(tile_binary, content_type=mime_type)

--- a/django-rgd-imagery/rgd_imagery/tasks/subsample.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/subsample.py
@@ -126,7 +126,7 @@ def extract_region(processed_image):
                 SampleTypes.GEO_BOX,
             ):
                 path, mime_type = large_image_utilities.get_region_world(
-                    tile_source, l, r, b, t, projection=projection
+                    tile_source, l, r, b, t, units=projection
                 )
             else:
                 path, mime_type = large_image_utilities.get_region_pixel(tile_source, l, r, b, t)

--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
@@ -175,4 +175,96 @@
 
   </script>
 
+
+  <!-- Section for extracting ROIs -->
+
+  <style>
+    .roiTool {
+      background-color: #DCDCDC;
+      padding: 2px;
+      border: 2px solid #000;
+      text-align: left;
+      border-radius: 10px;
+    }
+  </style>
+
+  <div id="roiTool" class="roiTool">
+    <div class="column is-full field is-grouped">
+      <div class="control">
+        <input class="button is-secondary" type="button" value="Draw ROI" id="drawROIButton" onclick="enableDrawROI()">
+      </div>
+      <a class="button has-icon is-flex is-justify-content-space-between is-secondary" id="extractROIButton">
+        <span>Download ROI</span>
+        <span class="icon is-small">
+          <i class="material-icons">download</i>
+        </span>
+      </a>
+    </div>
+  </div>
+
+  <script>
+    // Add ROI Tool to the GeoJS UI layer
+    var basemapTool = ui.createWidget('dom', {position: {right: 20, top: 60}});
+    basemapTool.canvas().appendChild(document.getElementById("roiTool"))
+
+    var roi;
+    function enableDrawROI() {
+      // Disable button until completed
+      var b1 = document.getElementById("drawROIButton")
+      var b2 = document.getElementById("extractROIButton")
+      b1.disabled = true
+      b2.disabled = true
+      // Clear any previous annotations
+      annotationLayer.removeAllAnnotations()
+      // Start new annotation
+      annotationLayer.mode('rectangle');
+      annotationLayer.geoOn(geo.event.annotation.state, (e) => {
+        if (e.annotation.state() === "done") {
+          var coords = e.annotation.coordinates();
+          // Re-enable button
+          b1.disabled = false
+          b2.disabled = false
+          // Get the bounding box
+          roi = {
+            left: coords[0].x,
+            right: coords[1].x,
+            bottom: coords[1].y,
+            top: coords[2].y
+          };
+          var xx = coords.forEach((p) => {
+            if (p.x < roi.left) {
+              roi.left = p.x
+            }
+            if (p.x > roi.right) {
+              roi.right = p.x
+            }
+            if (p.y < roi.bottom) {
+              roi.bottom = p.y
+            }
+            if (p.y > roi.top) {
+              roi.top = p.y
+            }
+          });
+        }
+        // Check if ROI is outside of the bounds of raster as this will
+        //   yield invalid results
+        if (roi.left < dataset_bb.xmin |
+          roi.right > dataset_bb.xmax |
+          roi.top > dataset_bb.ymax |
+          roi.bottom < dataset_bb.ymin) {
+            console.log('ROI exceeds the boundary of the source raster.')
+            // TODO: show toast with error message
+            b2.href = '#';
+        } else {
+          // Build a URL for extracting that ROI
+          var image_id = Number(imageSelector.value)
+          b2.href = `${host}/api/image_process/imagery/${image_id}/tiles/region/world/${roi.left}/${roi.right}/${roi.bottom}/${roi.top}/region.tif?units=EPSG:4326`
+        }
+
+      });
+    }
+
+
+  </script>
+
 {% endblock %}

--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
@@ -193,12 +193,9 @@
       <div class="control">
         <input class="button is-secondary" type="button" value="Draw ROI" id="drawROIButton" onclick="enableDrawROI()">
       </div>
-      <a class="button has-icon is-flex is-justify-content-space-between is-secondary" id="extractROIButton">
-        <span>Download ROI</span>
-        <span class="icon is-small">
-          <i class="material-icons">download</i>
-        </span>
-      </a>
+      <div class="control">
+        <input class="button is-secondary" type="button" id="extractROIButton" onclick="downloadROI()" value="Download" disabled="true">
+      </div>
     </div>
   </div>
 
@@ -246,22 +243,29 @@
             }
           });
         }
-        // Check if ROI is outside of the bounds of raster as this will
-        //   yield invalid results
-        if (roi.left < dataset_bb.xmin |
-          roi.right > dataset_bb.xmax |
-          roi.top > dataset_bb.ymax |
-          roi.bottom < dataset_bb.ymin) {
-            console.log('ROI exceeds the boundary of the source raster.')
-            // TODO: show toast with error message
-            b2.href = '#';
-        } else {
-          // Build a URL for extracting that ROI
-          var image_id = Number(imageSelector.value)
-          b2.href = `${host}/api/image_process/imagery/${image_id}/tiles/region/world/${roi.left}/${roi.right}/${roi.bottom}/${roi.top}/region.tif?units=EPSG:4326`
-        }
-
       });
+    }
+
+    function downloadROI() {
+      var image_id = Number(imageSelector.value)
+      if (image_id < 0) {
+        // No valid image selected
+        console.log('No valid image selected.')
+        return
+      }
+      // Check if ROI is outside of the bounds of raster as this will
+      //   yield invalid results
+      if (roi.left < dataset_bb.xmin |
+        roi.right > dataset_bb.xmax |
+        roi.top > dataset_bb.ymax |
+        roi.bottom < dataset_bb.ymin) {
+          console.log('ROI exceeds the boundary of the source raster.')
+          // TODO: show toast with error message
+          return
+      }
+      // Build a URL for extracting that ROI
+      var url = `${host}/api/image_process/imagery/${image_id}/tiles/region/world/${roi.left}/${roi.right}/${roi.bottom}/${roi.top}/region.tif?units=EPSG:4326`;
+      download(url, 'region.tif')
     }
 
 

--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
@@ -203,47 +203,53 @@
     // Add ROI Tool to the GeoJS UI layer
     var basemapTool = ui.createWidget('dom', {position: {right: 20, top: 60}});
     basemapTool.canvas().appendChild(document.getElementById("roiTool"))
-
+    var b1 = document.getElementById("drawROIButton")
+    var b2 = document.getElementById("extractROIButton")
     var roi;
+
+    // Add callback to annotation layer
+    annotationLayer.geoOn(geo.event.annotation.state, (e) => {
+      if (e.annotation.state() === "edit") {
+        // Prevent downloading while editing as last complete state is used and
+        //   could yield seemingly wrong results
+        b2.disabled = true
+      } else if (e.annotation.state() === "done") {
+        var coords = e.annotation.coordinates();
+        // Re-enable button
+        b1.disabled = false
+        b2.disabled = false
+        // Get the bounding box
+        roi = {
+          left: coords[0].x,
+          right: coords[1].x,
+          bottom: coords[1].y,
+          top: coords[2].y
+        };
+        var xx = coords.forEach((p) => {
+          if (p.x < roi.left) {
+            roi.left = p.x
+          }
+          if (p.x > roi.right) {
+            roi.right = p.x
+          }
+          if (p.y < roi.bottom) {
+            roi.bottom = p.y
+          }
+          if (p.y > roi.top) {
+            roi.top = p.y
+          }
+        });
+      }
+    });
+
     function enableDrawROI() {
       // Disable button until completed
-      var b1 = document.getElementById("drawROIButton")
-      var b2 = document.getElementById("extractROIButton")
       b1.disabled = true
       b2.disabled = true
       // Clear any previous annotations
       annotationLayer.removeAllAnnotations()
       // Start new annotation
       annotationLayer.mode('rectangle');
-      annotationLayer.geoOn(geo.event.annotation.state, (e) => {
-        if (e.annotation.state() === "done") {
-          var coords = e.annotation.coordinates();
-          // Re-enable button
-          b1.disabled = false
-          b2.disabled = false
-          // Get the bounding box
-          roi = {
-            left: coords[0].x,
-            right: coords[1].x,
-            bottom: coords[1].y,
-            top: coords[2].y
-          };
-          var xx = coords.forEach((p) => {
-            if (p.x < roi.left) {
-              roi.left = p.x
-            }
-            if (p.x > roi.right) {
-              roi.right = p.x
-            }
-            if (p.y < roi.bottom) {
-              roi.bottom = p.y
-            }
-            if (p.y > roi.top) {
-              roi.top = p.y
-            }
-          });
-        }
-      });
     }
 
     function downloadROI() {

--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/rastermeta_detail.html
@@ -196,6 +196,9 @@
       <div class="control">
         <input class="button is-secondary" type="button" id="extractROIButton" onclick="downloadROI()" value="Download" disabled="true">
       </div>
+      <div class="control">
+        <input class="button is-secondary" type="button" value="Clear" id="clearROIButton" onclick="clearROI()" disabled="true">
+      </div>
     </div>
   </div>
 
@@ -205,6 +208,7 @@
     basemapTool.canvas().appendChild(document.getElementById("roiTool"))
     var b1 = document.getElementById("drawROIButton")
     var b2 = document.getElementById("extractROIButton")
+    var b3 = document.getElementById("clearROIButton")
     var roi;
 
     // Add callback to annotation layer
@@ -246,6 +250,8 @@
       // Disable button until completed
       b1.disabled = true
       b2.disabled = true
+      // Make sure clear button is enabled
+      b3.disabled = false
       // Clear any previous annotations
       annotationLayer.removeAllAnnotations()
       // Start new annotation
@@ -272,6 +278,13 @@
       // Build a URL for extracting that ROI
       var url = `${host}/api/image_process/imagery/${image_id}/tiles/region/world/${roi.left}/${roi.right}/${roi.bottom}/${roi.top}/region.tif?units=EPSG:4326`;
       download(url, 'region.tif')
+    }
+
+    function clearROI() {
+      annotationLayer.removeAllAnnotations()
+      b1.disabled = false
+      b2.disabled = true
+      b3.disabled = true
     }
 
 

--- a/django-rgd-imagery/setup.py
+++ b/django-rgd-imagery/setup.py
@@ -51,6 +51,7 @@ setup(
         'large-image-source-gdal>=1.8.1.dev7',
         'large-image-source-pil>=1.8.1.dev7',
         'large-image-source-tiff>=1.8.1.dev7',
+        'pyvips',
         'tifftools>=1.2.0',
         'numpy',
         'pystac>=1.1.0',

--- a/django-rgd/rgd/templates/rgd/_base/base.html
+++ b/django-rgd/rgd/templates/rgd/_base/base.html
@@ -34,6 +34,18 @@
         if (ind1==-1) { ind1=theCookie.length; }
         return unescape(theCookie.substring(ind+cookieName.length+1,ind1));
       }
+
+      function download(url, filename) {
+        fetch(url)
+          .then(response => response.blob())
+          .then(blob => {
+            const link = document.createElement("a");
+            link.href = URL.createObjectURL(blob);
+            link.download = filename;
+            link.click();
+        })
+        .catch(console.error);
+      }
     </script>
 
     <link rel="stylesheet" href="{% static 'rgd/css/style.css' %}" />


### PR DESCRIPTION
This fixes the utils/endpoints we had for extracting regions from images and adds a new interface on the raster detail view page to select an ROI within the bounds of a raster and directly download that ROI.

Some things to address:

- [ ] Can we add a toast to alert the user that their ROI is outside the bounds of the raster?

If accessing a large dataset remotely, this will not be very RESTful . In the future (with the new SPA frontend), we should have this tool utilize the `ProcessedImage` model and do this asynchronously with polling to see if the job is done.


## Demo

| UI | Produced ROI |
|---|---|
| ![Screen Shot 2021-11-14 at 6 48 26 PM](https://user-images.githubusercontent.com/22067021/141710076-9a8f643a-429d-418f-9744-b5d743486812.png) |  ![Screen Shot 2021-11-14 at 6 53 27 PM](https://user-images.githubusercontent.com/22067021/141710144-3d43d6fe-043c-45df-858a-0fae385034f0.png) |

 