### PR TITLE
Set GDAL WMS cache config

### DIFF
--- a/django-rgd-imagery/rgd_imagery/__init__.py
+++ b/django-rgd-imagery/rgd_imagery/__init__.py
@@ -5,3 +5,10 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = None
+
+
+from osgeo import gdal
+from rgd.utility import get_temp_dir
+
+gdal.SetConfigOption('GDAL_ENABLE_WMS_CACHE', 'YES')
+gdal.SetConfigOption('GDAL_DEFAULT_WMS_CACHE_PATH', str(get_temp_dir() / 'gdalwmscache'))


### PR DESCRIPTION
Solution to https://github.com/girder/large_image/issues/681

This sets a default cache location for all WMS tile sources