### PR TITLE
POST endpoints for `rgd_geometry`

### DIFF
--- a/django-rgd-geometry/rgd_geometry/rest/viewsets.py
+++ b/django-rgd-geometry/rgd_geometry/rest/viewsets.py
@@ -1,5 +1,5 @@
 from rest_framework.decorators import action
-from rgd.rest.base import ReadOnlyModelViewSet
+from rgd.rest.base import ModelViewSet, ReadOnlyModelViewSet
 from rgd_geometry import models, serializers
 
 
@@ -13,3 +13,8 @@ class GeometryViewSet(ReadOnlyModelViewSet):
     )
     def data(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
+
+
+class GeometryArchiveViewSet(ModelViewSet):
+    serializer_class = serializers.GeometryArchiveSerializer
+    queryset = models.GeometryArchive.objects.all()

--- a/django-rgd-geometry/rgd_geometry/rest/viewsets.py
+++ b/django-rgd-geometry/rgd_geometry/rest/viewsets.py
@@ -1,9 +1,9 @@
 from rest_framework.decorators import action
-from rgd.rest.base import ModelViewSet, ReadOnlyModelViewSet
+from rgd.rest.base import ModelViewSet
 from rgd_geometry import models, serializers
 
 
-class GeometryViewSet(ReadOnlyModelViewSet):
+class GeometryViewSet(ModelViewSet):
     serializer_class = serializers.GeometrySerializer
     queryset = models.Geometry.objects.all()
 

--- a/django-rgd-geometry/rgd_geometry/serializers.py
+++ b/django-rgd-geometry/rgd_geometry/serializers.py
@@ -1,7 +1,12 @@
 import json
-from rgd.models.file import ChecksumFile
 
-from rgd.serializers import TASK_EVENT_READ_ONLY_FIELDS, ChecksumFileSerializer, RelatedField, SpatialEntrySerializer
+from rgd.models.file import ChecksumFile
+from rgd.serializers import (
+    TASK_EVENT_READ_ONLY_FIELDS,
+    ChecksumFileSerializer,
+    RelatedField,
+    SpatialEntrySerializer,
+)
 
 from . import models
 

--- a/django-rgd-geometry/rgd_geometry/serializers.py
+++ b/django-rgd-geometry/rgd_geometry/serializers.py
@@ -1,8 +1,18 @@
 import json
+from rgd.models.file import ChecksumFile
 
-from rgd.serializers import SpatialEntrySerializer
+from rgd.serializers import TASK_EVENT_READ_ONLY_FIELDS, ChecksumFileSerializer, RelatedField, SpatialEntrySerializer
 
 from . import models
+
+
+class GeometryArchiveSerializer(SpatialEntrySerializer):
+    file = RelatedField(queryset=ChecksumFile.objects.all(), serializer=ChecksumFileSerializer)
+
+    class Meta:
+        model = models.GeometryArchive
+        fields = '__all__'
+        read_only_fields = TASK_EVENT_READ_ONLY_FIELDS
 
 
 class GeometrySerializer(SpatialEntrySerializer):

--- a/django-rgd-geometry/rgd_geometry/urls.py
+++ b/django-rgd-geometry/rgd_geometry/urls.py
@@ -5,6 +5,7 @@ from rgd_geometry.rest import viewsets
 
 router = SimpleRouter(trailing_slash=False)
 router.register(r'api/rgd_geometry', viewsets.GeometryViewSet)
+router.register(r'api/rgd_geometry/geometry_archive', viewsets.GeometryArchiveViewSet)
 
 urlpatterns = [
     # Pages


### PR DESCRIPTION
- Adds serializer + viewset for `GeometryArchive`
- Enable POST/PUT/PATCH/DELETE operations on existing `Geometry` viewset
  - @banesullivan is this correct? That viewset currently inherits from `ReadOnlyModelViewSet` which disables POST operations, but it is listed in #452 as one of the models to have POST support for. 