### PR TITLE
POST endpoints for `rgd_fmv`

### DIFF
--- a/django-rgd-fmv/rgd_fmv/rest/viewsets.py
+++ b/django-rgd-fmv/rgd_fmv/rest/viewsets.py
@@ -1,11 +1,15 @@
 from rest_framework.decorators import action
-from rgd.rest.base import ReadOnlyModelViewSet
+from rgd.rest.base import ModelViewSet, ReadOnlyModelViewSet
 from rgd_fmv import models, serializers
 
 
-class FMVMetaViewSet(ReadOnlyModelViewSet):
-    serializer_class = serializers.FMVMetaSerializer
+class FMVMetaViewSet(ModelViewSet):
     queryset = models.FMVMeta.objects.all()
+
+    def get_serializer_class(self):
+        if self.action in ['get', 'list']:
+            return serializers.FMVMetaSerializer
+        return serializers.FMVSerializer
 
     @action(detail=True, serializer_class=serializers.FMVMetaDataSerializer)
     def data(self, request, *args, **kwargs):

--- a/django-rgd-fmv/rgd_fmv/rest/viewsets.py
+++ b/django-rgd-fmv/rgd_fmv/rest/viewsets.py
@@ -1,9 +1,9 @@
 from rest_framework.decorators import action
-from rgd.rest.base import ModelViewSet, ReadOnlyModelViewSet
+from rgd.rest.base import ModelViewSet
 from rgd_fmv import models, serializers
 
 
-class FMVMetaViewSet(ModelViewSet):
+class FMVViewSet(ModelViewSet):
     queryset = models.FMVMeta.objects.all()
 
     def get_serializer_class(self):

--- a/django-rgd-fmv/rgd_fmv/serializers.py
+++ b/django-rgd-fmv/rgd_fmv/serializers.py
@@ -1,17 +1,24 @@
 import json
 
 from rest_framework import serializers
-from rgd.serializers import ChecksumFileSerializer, SpatialEntrySerializer
+from rgd.models.file import ChecksumFile
+from rgd.serializers import (
+    TASK_EVENT_READ_ONLY_FIELDS,
+    ChecksumFileSerializer,
+    RelatedField,
+    SpatialEntrySerializer,
+)
 
 from . import models
 
 
 class FMVSerializer(serializers.ModelSerializer):
-    file = ChecksumFileSerializer()
+    file = RelatedField(queryset=ChecksumFile.objects.all(), serializer=ChecksumFileSerializer)
 
     class Meta:
         model = models.FMV
         fields = '__all__'
+        read_only_fields = TASK_EVENT_READ_ONLY_FIELDS + ['frame_rate']
 
 
 class FMVMetaSerializer(SpatialEntrySerializer):

--- a/django-rgd-fmv/rgd_fmv/urls.py
+++ b/django-rgd-fmv/rgd_fmv/urls.py
@@ -4,7 +4,7 @@ from rgd_fmv import models, views
 from rgd_fmv.rest import viewsets
 
 router = SimpleRouter(trailing_slash=False)
-router.register(r'api/rgd_fmv', viewsets.FMVMetaViewSet)
+router.register(r'api/rgd_fmv', viewsets.FMVViewSet)
 
 urlpatterns = [
     # Pages


### PR DESCRIPTION
Currently, `FMVMetaSerializer` is being used for general GET requests to `rgd_fmv`. However, I believe the correct behavior for a POST request is to only allow direct upload of a FMV file; it should not be allowed to modify the `FMVMeta` as that is autogenerated. That is what I implemented in this PR, but @banesullivan please correct me if I am wrong :slightly_smiling_face: 