### PR TITLE
Auth token param and ipyleaflet tile veiwer

### DIFF
--- a/django-rgd/client/rgd_client/client.py
+++ b/django-rgd/client/rgd_client/client.py
@@ -46,9 +46,7 @@ class RgdClient:
                         'Failed to retrieve API key; are your username and password correct?'
                     )
 
-        auth_header = f'Token {api_key}'
-
-        self.session = RgdClientSession(base_url=api_url, auth_header=auth_header)
+        self.session = RgdClientSession(base_url=api_url, auth_token=api_key)
         self.rgd = CorePlugin(clone_session(self.session))
 
     def clear_token(self):

--- a/django-rgd/client/rgd_client/session.py
+++ b/django-rgd/client/rgd_client/session.py
@@ -10,9 +10,7 @@ from ._version import __version__
 
 
 class RgdClientSession(BaseUrlSession):
-    def __init__(
-        self, base_url: str, auth_header: Optional[str] = None, retries: Optional[int] = 5
-    ):
+    def __init__(self, base_url: str, auth_token: Optional[str] = None, retries: Optional[int] = 5):
         """
         Initialize a session with a Resonant GeoData server.
 
@@ -33,8 +31,10 @@ class RgdClientSession(BaseUrlSession):
             }
         )
 
-        if auth_header:
-            self.headers['Authorization'] = auth_header
+        if auth_token:
+            self.headers['Authorization'] = f'Token {auth_token}'
+
+        self.rgd_auth_token = auth_token
 
         retry = Retry(
             total=retries, status_forcelist=[429, 503], method_whitelist=['GET'], backoff_factor=1
@@ -55,11 +55,13 @@ def clone_session(session: RgdClientSession):
     """
     Clone an existing RgdClientSession.
 
-    This is necessary as simply calling `copy.deepcopy` won't suffice, due to BaseUrlSession
-    defining `base_url` as a class/static variable. Since copy.deepcopy doesn't copy class
-    variables, `base_url` is `None` in the copied instance.
+    This is necessary as simply calling `copy.deepcopy` won't suffice, due to
+    BaseUrlSession defining `base_url` and `rgd_auth_token` as a class/static
+    variables. Since copy.deepcopy doesn't copy class variables, `base_url` is
+    `None` in the copied instance.
     """
     new_session = copy.deepcopy(session)
     new_session.base_url = session.base_url
+    new_session.rgd_auth_token = session.rgd_auth_token
 
     return new_session

--- a/django-rgd/rgd/configuration/configuration.py
+++ b/django-rgd/rgd/configuration/configuration.py
@@ -76,7 +76,7 @@ class ResonantGeoDataBaseMixin(GeoDjangoMixin, SwaggerMixin, ConfigMixin):
             'crum.CurrentRequestUserMiddleware',
         ]
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
-            'rest_framework.authentication.TokenAuthentication',
+            'rgd.rest.authentication.TokenAuthSupportQueryString',
         ]
 
         if getattr(configuration, 'DEBUG', False):

--- a/django-rgd/rgd/rest/authentication.py
+++ b/django-rgd/rgd/rest/authentication.py
@@ -1,0 +1,16 @@
+from rest_framework.authentication import TokenAuthentication
+
+
+class TokenAuthSupportQueryString(TokenAuthentication):
+    """
+    Extend the TokenAuthentication class to support querystring authentication
+    in the form of "http://www.example.com/?auth_token=<token_key>"
+    """
+
+    def authenticate(self, request):
+        # Check if 'token_auth' is in the request query params.
+        # Give precedence to 'Authorization' header.
+        if 'auth_token' in request.query_params and 'HTTP_AUTHORIZATION' not in request.META:
+            return self.authenticate_credentials(request.query_params.get('auth_token'))
+        else:
+            return super(TokenAuthSupportQueryString, self).authenticate(request)


### PR DESCRIPTION
These changes enable support for embedding the authentication token as a query parameter. This is for use cases where we want to "pre-sign" a URL for handing off to 3rd party software. Specifically, this is for the use case of generating a pre-signed tile URL for an image so that we can visualize it interactively with `ipyleafelt`.

@mvandenburgh and @AlmightyYakob, would you please review the changes to the authentication and python client?

-------

Here is an example with a new helper method in the `rgd_imagery_client`:

```py
from ipyleaflet import Map, projections, ScaleControl, FullScreenControl
from rgd_client import create_rgd_client

client = create_rgd_client(username='email@kitware.com', api_url='http://localhost:8000/api')

t = client.imagery.get_leaflet_tile_source(18, band=1, palette='matplotlib.Viridis_20', vmin=50, vmax=200)

m = Map(
        center=(37.7249511580583, -122.27230466902257), 
        zoom=9, crs=projections.EPSG3857, 
       )

m.add_layer(t)
m
```

<img width="968" alt="Screen Shot 2021-11-20 at 11 34 08 AM" src="https://user-images.githubusercontent.com/22067021/142737415-5a9bc646-40b4-4027-b753-fdfe56195f27.png">

