### PR TITLE
Cache tile queries

### DIFF
--- a/django-rgd-imagery/tests/test_tiles.py
+++ b/django-rgd-imagery/tests/test_tiles.py
@@ -29,3 +29,12 @@ def test_thumbnail(admin_api_client, geotiff_image_entry):
     )
     assert response.status_code == 200
     assert response['Content-Type'] == 'image/png'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_cache(admin_api_client, geotiff_image_entry, django_assert_num_queries):
+    # cache a response
+    admin_api_client.get(f'/api/image_process/imagery/{geotiff_image_entry.pk}/tiles/1/0/0.png')
+    # ensure no new queries are made for a different tile request made by same user on same image
+    with django_assert_num_queries(0):
+        admin_api_client.get(f'/api/image_process/imagery/{geotiff_image_entry.pk}/tiles/1/1/0.png')

--- a/django-rgd/rgd/configuration/configuration.py
+++ b/django-rgd/rgd/configuration/configuration.py
@@ -46,6 +46,7 @@ class MemachedMixin(ConfigMixin):
     MEMCACHED_USERNAME = values.Value(default=None)
     MEMCACHED_PASSWORD = values.Value(default=None)
     MEMCACHED_BINARY = values.Value(default=True)
+    SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
     @classmethod
     def post_setup(cls):


### PR DESCRIPTION
Closes #604

In order to serve a tile, information must be known about it from our database. The tile endpoint recieves many concurrent connections. As a result, the connection limit to PostgreSQL was getting exhausted.

This PR:
- Uses memcached to store session information
- Caches database queries required to serve different tiles from the same base image
- Tests that no consecutive calls to the tile endpoint will access the database