### PR TITLE
Optimized STAC queries

### DIFF
--- a/django-rgd-imagery/rgd_imagery/stac/serializers/item/__init__.py
+++ b/django-rgd-imagery/rgd_imagery/stac/serializers/item/__init__.py
@@ -25,9 +25,6 @@ class ItemSerializer(serializers.BaseSerializer):
         asset_eo_ext = EOExtension.ext(asset, add_if_missing=True)
         asset_eo_ext.bands = [
             band_utils.to_pystac(bandmeta)
-            # for bandmeta in image.bandmeta_set.filter(
-            #     band_range__contained_by=(None, None),
-            # )
             for bandmeta in image.bandmeta_set.all()
             if bandmeta.band_range
         ]

--- a/django-rgd-imagery/rgd_imagery/stac/tests.py
+++ b/django-rgd-imagery/rgd_imagery/stac/tests.py
@@ -44,3 +44,9 @@ def test_eo_serialize(sample_raster_url):
                 assert 'common_name' in band or (
                     'center_wavelength' in band and 'full_width_half_max' in band
                 )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_optimized_query(admin_api_client, sample_raster_url, django_assert_num_queries):
+    with django_assert_num_queries(6):
+        admin_api_client.get('/api/stac/collection/default/items')

--- a/django-rgd-imagery/rgd_imagery/stac/views.py
+++ b/django-rgd-imagery/rgd_imagery/stac/views.py
@@ -24,7 +24,9 @@ class OptimizedRasterMetaQuerysetMixin:
                 .prefetch_related(
                     Prefetch(
                         'processedimage_set',
-                        queryset=models.ProcessedImage.objects.prefetch_related('source_images'),
+                        queryset=models.ProcessedImage.objects.select_related(
+                            'processed_image'
+                        ).select_related('processed_image__file'),
                     )
                 )
                 .prefetch_related('bandmeta_set')


### PR DESCRIPTION
Viewing large collections of STAC items would take a long time. If N is the number of STAC items in a collection, 12N+1 queries were made.

This PR reduces the number of queries down to 6. The number of queries is independent of the number of STAC items in a collection.