### PR TITLE
Optimized SpatialEntrySerializer and all subclasses

### DIFF
--- a/django-rgd-fmv/rgd_fmv/serializers.py
+++ b/django-rgd-fmv/rgd_fmv/serializers.py
@@ -31,7 +31,6 @@ class FMVMetaSerializer(SpatialEntrySerializer):
             'ground_union',
             'flight_path',
             'frame_numbers',
-            'outline',
             'footprint',
         ]
 

--- a/django-rgd-geometry/rgd_geometry/serializers.py
+++ b/django-rgd-geometry/rgd_geometry/serializers.py
@@ -23,7 +23,7 @@ class GeometryArchiveSerializer(SpatialEntrySerializer):
 class GeometrySerializer(SpatialEntrySerializer):
     class Meta:
         model = models.Geometry
-        exclude = ['data', 'footprint', 'outline']
+        exclude = ['data', 'footprint']
 
 
 class GeometryDataSerializer(GeometrySerializer):

--- a/django-rgd-imagery/rgd_imagery/serializers/raster.py
+++ b/django-rgd-imagery/rgd_imagery/serializers/raster.py
@@ -34,5 +34,5 @@ class RasterMetaSerializer(SpatialEntrySerializer):
 
     class Meta:
         model = models.RasterMeta
-        exclude = ['footprint', 'outline']
+        exclude = ['footprint']
         # read_only_fields - This serializer should be used read-only

--- a/django-rgd/rgd/serializers.py
+++ b/django-rgd/rgd/serializers.py
@@ -6,7 +6,7 @@ from . import models
 
 MODIFIABLE_READ_ONLY_FIELDS = ['modified', 'created']
 TASK_EVENT_READ_ONLY_FIELDS = ['status', 'failure_reason']
-SPATIAL_ENTRY_EXCLUDE = ['footprint', 'outline']
+SPATIAL_ENTRY_EXCLUDE = ['footprint']
 
 
 class RelatedField(serializers.PrimaryKeyRelatedField):


### PR DESCRIPTION
Each serializer that inherited from `SpatialEntrySerializers` would execute a SQL query when evaluated. In other words, if 10 items were requested, 10 superfulous SQL queries were made. This PR removes this behavior. It also cleans up the way the serializer works by relying on `SerializerMethodField`.