### PR TITLE
[hotfix] Pin num queries lower for no permissions

### DIFF
--- a/django-rgd-imagery/rgd_imagery/stac/tests.py
+++ b/django-rgd-imagery/rgd_imagery/stac/tests.py
@@ -50,5 +50,5 @@ def test_eo_serialize(sample_raster_url):
 
 @pytest.mark.django_db(transaction=True)
 def test_optimized_query(admin_api_client, sample_raster_url, django_assert_num_queries):
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(2):
         admin_api_client.get('/api/stac/collection/default/items')


### PR DESCRIPTION
Due to patch to reduce permissions, a test was failing that asserted query count.