### PR TITLE
Use inner joins for the permissions query

### DIFF
--- a/django-rgd-fmv/rgd_fmv/views.py
+++ b/django-rgd-fmv/rgd_fmv/views.py
@@ -1,23 +1,20 @@
 import json
 
-from rgd.views import _SpatialDetailView
+from rgd.views import SpatialDetailView
 
 from . import models
 
 
-class FMVMetaDetailView(_SpatialDetailView):
+class FMVMetaDetailView(SpatialDetailView):
     model = models.FMVMeta
-
-    def _get_extent(self, object):
-        extent = super()._get_extent(object)
-        if object.ground_union is not None:
-            # All or none of these will be set, only check one
-            extent['collect'] = object.ground_union.json
-            extent['ground_frames'] = object.ground_frames.json
-            extent['frame_numbers'] = object._blob_to_array(object.frame_numbers)
-        return extent
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['frame_rate'] = json.dumps(self.object.fmv_file.frame_rate)
+        extents = context['extents']
+        if self.object.ground_union is not None:
+            # All or none of these will be set, only check one
+            extents['collect'] = self.object.ground_union.json
+            extents['ground_frames'] = self.object.ground_frames.json
+            extents['frame_numbers'] = self.object._blob_to_array(self.object.frame_numbers)
         return context

--- a/django-rgd-geometry/rgd_geometry/views.py
+++ b/django-rgd-geometry/rgd_geometry/views.py
@@ -1,12 +1,13 @@
-from rgd.views import _SpatialDetailView
+from rgd.views import SpatialDetailView
 
 from . import models
 
 
-class GeometryDetailView(_SpatialDetailView):
+class GeometryDetailView(SpatialDetailView):
     model = models.Geometry
 
-    def _get_extent(self, object):
-        extent = super()._get_extent(object)
-        extent['data'] = object.data.json
-        return extent
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        extents = context['extents']
+        extents['data'] = self.object.data.json
+        return context

--- a/django-rgd-imagery/rgd_imagery/views.py
+++ b/django-rgd-imagery/rgd_imagery/views.py
@@ -1,8 +1,8 @@
 from rgd.views import (
     PermissionDetailView,
     PermissionTemplateView,
+    SpatialDetailView,
     SpatialEntriesListView,
-    _SpatialDetailView,
 )
 
 from . import filters, models
@@ -13,13 +13,12 @@ class ImageSetDetailView(PermissionDetailView):
 
 
 class RasterMetaEntriesListView(SpatialEntriesListView):
-    model = models.RasterMeta
-    filter = filters.RasterMetaFilter
-    context_object_name = 'spatial_entries'
+    queryset = models.RasterMeta.objects.all()
     template_name = 'rgd_imagery/rastermeta_list.html'
+    filterset_class = filters.RasterMetaFilter
 
 
-class RasterDetailView(_SpatialDetailView):
+class RasterDetailView(SpatialDetailView):
     model = models.RasterMeta
 
 

--- a/django-rgd/rgd/views.py
+++ b/django-rgd/rgd/views.py
@@ -41,20 +41,21 @@ def query_params(params):
     return '&' + query.urlencode() if query.urlencode() else ''
 
 
-class _SpatialListView(PermissionListView):
+class SpatialListView(PermissionListView):
     paginate_by = 15
 
-    def _get_extent_summary(self, object_list):
-        ids = [o.spatial_id for o in object_list]
-        queryset = self.get_queryset().filter(spatial_id__in=ids)
-        summary = queryset.aggregate(
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        summary = self.object_list.aggregate(
             Collect('outline'),
             Extent('outline'),
+            Count('pk'),
         )
-        extents = {
-            'count': queryset.count(),
-        }
-        if queryset.count():
+        # Have a smaller dict of meta fields to parse for menu bar
+        # This keeps us from parsing long GeoJSON fields twice
+        context['extents_meta'] = json.dumps({'count': summary['pk__count']})
+        extents = {'count': summary['pk__count']}
+        if summary['pk__count']:
             extents.update(
                 {
                     'collect': json.loads(summary['outline__collect'].geojson),
@@ -67,33 +68,21 @@ class _SpatialListView(PermissionListView):
                     },
                 }
             )
-        return extents
-
-    def get_context_data(self, *args, **kwargs):
-        # Pagination happens here
-        context = super().get_context_data(*args, **kwargs)
-        summary = self._get_extent_summary(context['object_list'])
-        context['extents'] = json.dumps(summary)
-        # Have a smaller dict of meta fields to parse for menu bar
-        # This keeps us from parsing long GeoJSON fields twice
-        meta = {
-            'count': self.get_queryset().count(),  # This is the amount in the full results
-        }
-        context['extents_meta'] = json.dumps(meta)
+        context['extents'] = json.dumps(extents)
         context['search_params'] = json.dumps(self.request.GET)
         context['query_params'] = query_params(self.request.GET)
         return context
 
 
-class SpatialEntriesListView(_SpatialListView):
-    model = models.SpatialEntry
-    filter = filters.SpatialEntryFilter
+class SpatialEntriesListView(SpatialListView):
+    queryset = models.SpatialEntry.objects.select_subclasses()
     context_object_name = 'spatial_entries'
     template_name = 'rgd/spatialentry_list.html'
+    filterset_class = filters.SpatialEntryFilter
 
     def get_queryset(self):
-        filterset = self.filter(data=self.request.GET)
-        queryset = self.model.objects.select_subclasses().order_by('spatial_id')
+        queryset = super().get_queryset()
+        filterset = self.filterset_class(data=self.request.GET)
         if not filterset.is_valid():
             message = 'Filter parameters illformed. Full results returned.'
             all_error_messages_content = [
@@ -103,9 +92,9 @@ class SpatialEntriesListView(_SpatialListView):
             ]
             if message not in all_error_messages_content:
                 messages.add_message(self.request, messages.ERROR, message)
-            return queryset
-        queryset = filterset.filter_queryset(queryset)
-        return permissions.filter_read_perm(self.request.user, queryset)
+        else:
+            queryset = filterset.filter_queryset(queryset)
+        return queryset
 
 
 class StatisticsView(PermissionListView):
@@ -117,7 +106,7 @@ class StatisticsView(PermissionListView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context.update(
-            self.get_queryset().aggregate(
+            self.object_list.aggregate(
                 count=Count('spatial_id', distinct=True),
                 coordinates=ArrayAgg(AsGeoJSON(Centroid('footprint'))),
                 instrumentation_count=Count(
@@ -147,25 +136,20 @@ class StatisticsView(PermissionListView):
         return context
 
 
-class _SpatialDetailView(PermissionDetailView):
-    def _get_extent(self, object):
-        extent = {
-            'count': 0,
-        }
-        if object.footprint:
-            extent.update(
-                {
-                    'count': 1,
-                    'collect': object.footprint.json,
-                    'outline': object.outline.json,
-                    'extent': object.bounds,
-                }
-            )
-        return extent
-
+class SpatialDetailView(PermissionDetailView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['extents'] = json.dumps(self._get_extent(self.object))
+        extents = {'count': 0}
+        if self.object.footprint:
+            extents.update(
+                {
+                    'count': 1,
+                    'collect': self.object.footprint.json,
+                    'outline': self.object.outline.json,
+                    'extent': self.object.bounds,
+                }
+            )
+        context['extents'] = json.dumps(extents)
         return context
 
 


### PR DESCRIPTION
This causes the permissions query to use a union of inner joins which is much more performant than the left joins it defaulted to. It also cleans up the views.