### PR TITLE
Select subclasses for SpatialEntry viewset

### DIFF
--- a/django-rgd/rgd/rest/viewsets.py
+++ b/django-rgd/rgd/rest/viewsets.py
@@ -93,7 +93,7 @@ class ChecksumFileViewSet(ModelViewSet, TaskEventViewSetMixin):
 
 class SpatialEntryViewSet(ReadOnlyModelViewSet):
     serializer_class = serializers.SpatialEntrySerializer
-    queryset = models.SpatialEntry.objects.all()
+    queryset = models.SpatialEntry.objects.select_subclasses()
     filterset_class = SpatialEntryFilter
 
     @swagger_auto_schema(


### PR DESCRIPTION
https://github.com/ResonantGeoData/ResonantGeoData/pull/611 unexpectedly broke a test. This is a hotfix to fix it.