### PR TITLE
Need full zooming on image set viewer

### DIFF
--- a/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/imageset_detail.html
+++ b/django-rgd-imagery/rgd_imagery/templates/rgd_imagery/imageset_detail.html
@@ -117,6 +117,12 @@
 
       const imageViewer = geo.map(params.map);
 
+      imageViewer.zoomRange({
+          // do not set a min limit so that bounds clamping determines min
+          min: -Infinity,
+          max: 12,
+        });
+
       // remove old layer if it exists
       if (imageLayer) {
         imageViewer.deleteLayer(imageLayer);


### PR DESCRIPTION
Follow up to #523 to enable bigger zoom range when viewer non-geospatial images. Needed for demo ASAP... if this isn't the right way, we can fix later