### PR TITLE
Test RGD_GLOBAL_READ_ACCESS for Collections

### DIFF
--- a/django-rgd/rgd/permissions.py
+++ b/django-rgd/rgd/permissions.py
@@ -141,7 +141,13 @@ def filter_perm(user, queryset, role):
     # Check permissions
     conditions = []
     model = queryset.model
-    for path in get_paths(model, models.ChecksumFile):
+    paths_to_checksumfile = [*get_paths(model, models.ChecksumFile)]
+    if model == models.Collection:
+        # Add custom reverse relationships
+        field = model._meta.get_field('checksumfiles')
+        path = Path(field)
+        paths_to_checksumfile.append(path)
+    for path in paths_to_checksumfile:
         # A user can read/write a file if they are the creator
         is_creator = path.q(created_by=user)
         conditions.append(is_creator)

--- a/django-rgd/tests/test_permissions.py
+++ b/django-rgd/tests/test_permissions.py
@@ -18,9 +18,17 @@ def test_unassigned_permissions_complex(
     basic_q = filter_read_perm(user, models.SpatialEntry.objects.all())
     assert len(admin_q) == 2
     assert len(basic_q) == 0
+    admin_q = filter_read_perm(admin, models.Collection.objects.all())
+    basic_q = filter_read_perm(user, models.Collection.objects.all())
+    assert len(admin_q) == 2
+    assert len(basic_q) == 0
     settings.RGD_GLOBAL_READ_ACCESS = True
     admin_q = filter_read_perm(admin, models.SpatialEntry.objects.all())
     basic_q = filter_read_perm(user, models.SpatialEntry.objects.all())
+    assert len(admin_q) == len(basic_q)
+    assert set(admin_q) == set(basic_q)
+    admin_q = filter_read_perm(admin, models.Collection.objects.all())
+    basic_q = filter_read_perm(user, models.Collection.objects.all())
     assert len(admin_q) == len(basic_q)
     assert set(admin_q) == set(basic_q)
 


### PR DESCRIPTION
Address issue mentioned in #612 

There is an issue filtering on `Collection`s with `RGD_GLOBAL_READ_ACCESS` enabled. This test highlights the issue:

```
    @pytest.mark.django_db(transaction=True)
    def test_unassigned_permissions_complex(
        user_factory, user, spatial_asset_a, spatial_asset_b, settings
    ):
        # TODO: reimplement with multi raster file fixture also
        settings.RGD_GLOBAL_READ_ACCESS = False
        admin = user_factory(is_superuser=True)
        admin_q = filter_read_perm(admin, models.SpatialEntry.objects.all())
        basic_q = filter_read_perm(user, models.SpatialEntry.objects.all())
        assert len(admin_q) == 2
        assert len(basic_q) == 0
        admin_q = filter_read_perm(admin, models.Collection.objects.all())
        basic_q = filter_read_perm(user, models.Collection.objects.all())
        assert len(admin_q) == 2
        assert len(basic_q) == 0
        settings.RGD_GLOBAL_READ_ACCESS = True
        admin_q = filter_read_perm(admin, models.SpatialEntry.objects.all())
        basic_q = filter_read_perm(user, models.SpatialEntry.objects.all())
        assert len(admin_q) == len(basic_q)
        assert set(admin_q) == set(basic_q)
        admin_q = filter_read_perm(admin, models.Collection.objects.all())
        basic_q = filter_read_perm(user, models.Collection.objects.all())
>       assert len(admin_q) == len(basic_q)
E       assert 2 == 0
E         +2
E         -0
```