### PR TITLE
[draft] Auto-reload `celery` on code changes

### DIFF
--- a/dev/celery.Dockerfile
+++ b/dev/celery.Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
         libglib2.0-0 \
         ffmpeg \
         fuse \
+        python3-watchdog \
         && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,8 +24,8 @@ services:
       dockerfile: ./dev/celery.Dockerfile
     command: [
       "watchmedo", "auto-restart",
-      "--pattern", "*.py",
-      "--ignore-patterns", "./.tox/*",
+      "--pattern", "*.py;",
+      "--ignore-patterns", "./.tox/**/*.py",
       "--recursive",
       "--",
       "celery",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,6 +23,10 @@ services:
       context: .
       dockerfile: ./dev/celery.Dockerfile
     command: [
+      "watchmedo", "auto-restart",
+      "--pattern", "*.py",
+      "--recursive",
+      "--",
       "celery",
       "--app", "rgd_example.celery",
       "worker",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,6 +25,7 @@ services:
     command: [
       "watchmedo", "auto-restart",
       "--pattern", "*.py",
+      "--ignore-patterns", "./.tox/*",
       "--recursive",
       "--",
       "celery",


### PR DESCRIPTION
Not finished yet; `watchmedo` needs to be configured so it ignores `.py` files in certain directories such as `.tox/` (otherwise launching `tox` causes the celery worker to freeze up because it's being restarted so much).