### PR TITLE
Reorder `rgd_image` URLs

### DIFF
--- a/django-rgd-imagery/rgd_imagery/urls.py
+++ b/django-rgd-imagery/rgd_imagery/urls.py
@@ -4,9 +4,9 @@ from rgd_imagery import models, rest, views
 from rgd_imagery.rest import viewsets
 
 router = SimpleRouter(trailing_slash=False)
-router.register(r'api/image_process', viewsets.ProcessedImageViewSet)
 router.register(r'api/image_process/group', viewsets.ProcessedImageGroupViewSet)
 router.register(r'api/rgd_imagery/image_set', viewsets.ImageSetViewSet)
+router.register(r'api/image_process', viewsets.ProcessedImageViewSet)
 router.register(r'api/rgd_imagery/image_set_spatial', viewsets.ImageSetSpatialViewSet)
 router.register(r'api/rgd_imagery/raster', viewsets.RasterViewSet, basename='raster')
 router.register(r'api/rgd_imagery', viewsets.ImageViewSet, basename='imagery')

--- a/django-rgd-imagery/rgd_imagery/urls.py
+++ b/django-rgd-imagery/rgd_imagery/urls.py
@@ -5,9 +5,9 @@ from rgd_imagery.rest import viewsets
 
 router = SimpleRouter(trailing_slash=False)
 router.register(r'api/image_process/group', viewsets.ProcessedImageGroupViewSet)
-router.register(r'api/rgd_imagery/image_set', viewsets.ImageSetViewSet)
 router.register(r'api/image_process', viewsets.ProcessedImageViewSet)
 router.register(r'api/rgd_imagery/image_set_spatial', viewsets.ImageSetSpatialViewSet)
+router.register(r'api/rgd_imagery/image_set', viewsets.ImageSetViewSet)
 router.register(r'api/rgd_imagery/raster', viewsets.RasterViewSet, basename='raster')
 router.register(r'api/rgd_imagery', viewsets.ImageViewSet, basename='imagery')
 


### PR DESCRIPTION
Closes https://github.com/ResonantGeoData/ResonantGeoData/issues/644

URLs are routed greedily. For example, in the following:

```python
router = SimpleRouter(trailing_slash=False)
router.register(r'api/a', SerializerA)
router.register(r'api/a/b', SerializerAB)
```

... a `POST` to `/api/a/b` would actually use `SerializerA` since the route is a full match.

This PR corrects the orders of URLs in the `rgd_image` application to prevent this issue.