### PR TITLE
Add `file_tree_search` client method

### DIFF
--- a/django-rgd/client/rgd_client/plugin.py
+++ b/django-rgd/client/rgd_client/plugin.py
@@ -135,3 +135,18 @@ class CorePlugin(RgdPlugin):
 
         r.raise_for_status()
         return r.json()
+
+    def file_tree_search(self, path: str = ''):
+        """
+        Search files in a hierarchical format, from a provided folder path.
+
+        This endpoint returns all files and folders that are "within" the specified "folder" (the path argument).
+        An example is
+
+        Args:
+            path: The path to apply to the search. This can be thought of as the folder path that you'd like to search.
+
+        Returns:
+            A dictionary, containing all direct subfolders (`folders`), and files (`files`) under the specified path.
+        """
+        return self.session.get('checksum_file/tree', params={'path_prefix': path}).json()

--- a/django-rgd/tests/test_client.py
+++ b/django-rgd/tests/test_client.py
@@ -48,6 +48,14 @@ def test_create_file_from_url_existing(
 
 
 @pytest.mark.django_db(transaction=True)
+def test_tree_file_search(py_client: RgdClient, checksum_file: ChecksumFile):
+    """Test that basic connection to the tree endpoint succeeds."""
+    resp_dict = py_client.rgd.file_tree_search()
+    assert 'folders' in resp_dict
+    assert 'files' in resp_dict
+
+
+@pytest.mark.django_db(transaction=True)
 def test_save_api_key(live_server, user_with_api_key):
     """Test that saving an API key works correctly."""
     username, password, api_token = user_with_api_key


### PR DESCRIPTION
Addresses part of #629

Note: The test for this client method is intentionally brief, as the endpoint itself already has its own tests, and rewriting those for the client would be redundant.

This PR made me consider the following: Should we be modeling the data in python with Dataclasses / Pydantic / etc.? Would it provide value? Or should we just keep things as dicts. I wouldn't address this here, but just a thought. cc @banesullivan 