### PR TITLE
Remove RGD_STAC_BROWSER_LIMIT

### DIFF
--- a/django-rgd-imagery/README.md
+++ b/django-rgd-imagery/README.md
@@ -29,7 +29,6 @@ INSTALLED_APPS += [
 
 The RGD imagery submodule has an optional setting:
 
-- `RGD_STAC_BROWSER_LIMIT`: (default of 1000) limit the response of STAC collection queries. An exception will be raised if a collection is requested with more than this many items.
 - Use the `MEMCACHE_*` options from `django-rgd` to configure `large_image` for use with Memcached.
 
 ## Models

--- a/django-rgd-imagery/rgd_imagery/stac/tests.py
+++ b/django-rgd-imagery/rgd_imagery/stac/tests.py
@@ -1,7 +1,4 @@
-import re
-
 import pytest
-from rgd.models import ChecksumFile
 from rgd_imagery.stac.serializers import ItemSerializer
 
 

--- a/django-rgd-imagery/rgd_imagery/stac/tests.py
+++ b/django-rgd-imagery/rgd_imagery/stac/tests.py
@@ -6,21 +6,6 @@ from rgd_imagery.stac.serializers import ItemSerializer
 
 
 @pytest.mark.django_db(transaction=True)
-def test_stac_browser_limit(settings, admin_api_client, sample_raster_url):
-    ChecksumFile.objects.update(collection=None)
-    response = admin_api_client.get('/api/stac/collection/default/items')
-    assert response.status_code == 200
-    settings.RGD_STAC_BROWSER_LIMIT = 1
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "'RGD_STAC_BROWSER_LIMIT' (1) exceeded. Requested collection with 3 items."
-        ),
-    ):
-        response = admin_api_client.get('/api/stac/collection/default/items')
-
-
-@pytest.mark.django_db(transaction=True)
 def test_raster_stac_serializer_simple(sample_raster_url_single):
     data = ItemSerializer().to_representation(sample_raster_url_single)
     assets = data['assets']

--- a/django-rgd-imagery/rgd_imagery/stac/tests.py
+++ b/django-rgd-imagery/rgd_imagery/stac/tests.py
@@ -32,5 +32,5 @@ def test_eo_serialize(sample_raster_url):
 
 @pytest.mark.django_db(transaction=True)
 def test_optimized_query(admin_api_client, sample_raster_url, django_assert_num_queries):
-    with django_assert_num_queries(2):
+    with django_assert_num_queries(1):
         admin_api_client.get('/api/stac/collection/default/items')

--- a/django-rgd-imagery/rgd_imagery/stac/views.py
+++ b/django-rgd-imagery/rgd_imagery/stac/views.py
@@ -74,17 +74,11 @@ class ItemCollectionView(OptimizedRasterMetaQuerysetMixin, BaseRestViewMixin, Ge
 
     def get(self, request, *args, collection_id=None, **kwargs):
         collection_id = None if collection_id == 'default' else collection_id
-        queryset = self.get_queryset().filter(
-            parent_raster__image_set__images__file__collection=collection_id
-        )
-        # Test if queryset is too large
-        stac_browser_limit = getattr(settings, 'RGD_STAC_BROWSER_LIMIT', 1000)
-        num_items = queryset.count()
-        if num_items > stac_browser_limit:
-            raise ValueError(
-                f"'RGD_STAC_BROWSER_LIMIT' ({stac_browser_limit}) exceeded. "
-                f'Requested collection with {num_items} items.'
+        queryset = self.filter_queryset(
+            self.get_queryset().filter(
+                parent_raster__image_set__images__file__collection=collection_id
             )
+        )
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page)

--- a/django-rgd-imagery/rgd_imagery/stac/views.py
+++ b/django-rgd-imagery/rgd_imagery/stac/views.py
@@ -69,6 +69,8 @@ class ItemCollectionView(OptimizedRasterMetaQuerysetMixin, BaseRestViewMixin, Ge
     """See the Items in the Collection."""
 
     serializer_class = serializers.ItemCollectionSerializer
+    pagination_class = STACPagination
+    filterset_class = STACSimpleFilter
 
     def get(self, request, *args, collection_id=None, **kwargs):
         collection_id = None if collection_id == 'default' else collection_id
@@ -83,6 +85,10 @@ class ItemCollectionView(OptimizedRasterMetaQuerysetMixin, BaseRestViewMixin, Ge
                 f"'RGD_STAC_BROWSER_LIMIT' ({stac_browser_limit}) exceeded. "
                 f'Requested collection with {num_items} items.'
             )
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page)
+            return self.get_paginated_response(serializer.data)
         serializer = self.get_serializer(queryset)
         return Response(serializer.data)
 

--- a/django-rgd-imagery/rgd_imagery/stac/views.py
+++ b/django-rgd-imagery/rgd_imagery/stac/views.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.db.models import Prefetch
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response

--- a/django-rgd/rgd/configuration/configuration.py
+++ b/django-rgd/rgd/configuration/configuration.py
@@ -107,7 +107,6 @@ class ResonantGeoDataBaseMixin(GeoDjangoMixin, SwaggerMixin, ConfigMixin):
     RGD_GLOBAL_READ_ACCESS = values.Value(default=False)
     RGD_AUTO_APPROVE_SIGN_UP = values.Value(default=False)
     RGD_AUTO_COMPUTE_CHECKSUMS = values.Value(default=False)
-    RGD_STAC_BROWSER_LIMIT = values.Value(default=1000)
     RGD_TEMP_DIR = values.Value(default=os.path.join(tempfile.gettempdir(), 'rgd'))
     RGD_TARGET_AVAILABLE_CACHE = values.Value(default=2)
     RGD_REST_CACHE_TIMEOUT = values.Value(default=60 * 60 * 2)


### PR DESCRIPTION
Closes https://github.com/ResonantGeoData/ResonantGeoData/issues/654

We previously had to impose this hard limit to deal with STAC Browser and the lack of pagination it allowed. Now, the STAC API supports pagination in the STAC ItemCollection view. This PR brings in that already implemented feature.