### PR TITLE
Pin django-rgd dep in subpackages

### DIFF
--- a/django-rgd-3d/setup.py
+++ b/django-rgd-3d/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'django-rgd',
+        f'django-rgd=={__version__}',
     ],
     extras_require={
         'worker': [

--- a/django-rgd-fmv/setup.py
+++ b/django-rgd-fmv/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'django-rgd',
+        f'django-rgd=={__version__}',
     ],
     extras_require={
         'worker': [

--- a/django-rgd-geometry/setup.py
+++ b/django-rgd-geometry/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'django-rgd',
+        f'django-rgd=={__version__}',
     ],
     extras_require={
         'worker': [

--- a/django-rgd-imagery/setup.py
+++ b/django-rgd-imagery/setup.py
@@ -46,7 +46,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'bidict',
-        'django-rgd',
+        f'django-rgd=={__version__}',
         'large-image[memcached]>=1.8.1.dev7',
         'large-image-source-gdal>=1.8.1.dev7',
         'large-image-source-pil>=1.8.1.dev7',


### PR DESCRIPTION
RGD is not stable enough to guarantee cross-version compatibility between the core package and subpackages. For this reason, they currently share the same versions.

To further safeguard this, `django-rgd` should be pinned in the subpackages to guarantee a working installation.

Also, I think/hope this will improve using dependabot as it should pick up on the coupled dependencies so that all of these packages get bumped in a single PR instead of an individual PR for each subpackage