### PR TITLE
Miniforge docker image and publish images to ghcr.io

### DIFF
--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-file: [miniforge, django, celery]
+        docker-file: [miniforge, django, celery, sass]
     steps:
       - uses: actions/checkout@v2
       - name: Log into the Container registry

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -1,0 +1,40 @@
+name: Docker Package
+on:
+  push:
+    tags: "*"
+    branches:
+      - main
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-file: [miniforge, django, celery]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.docker-file }}
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dev/${{ matrix.docker-file }}.Dockerfile
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +36,6 @@ jobs:
         with:
           context: .
           file: dev/${{ matrix.docker-file }}.Dockerfile
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -36,6 +36,6 @@ jobs:
         with:
           context: .
           file: dev/${{ matrix.docker-file }}.Dockerfile
-          push: true
+          push: ${{ github.actor != "dependabot[bot]" }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-package.yml
+++ b/.github/workflows/docker-package.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/dev/miniforge.Dockerfile
+++ b/dev/miniforge.Dockerfile
@@ -1,0 +1,35 @@
+FROM condaforge/miniforge3
+LABEL "repository"="https://github.com/ResonantGeoData/ResonantGeoData"
+LABEL "maintainer"="Kitware, Inc. <rgd@kitware.com>"
+
+###############################################################################
+#### Install ALL dependencies are managed by environment.yml
+COPY environment.yml /opt/django-project/
+RUN conda env update --name base --file /opt/django-project/environment.yml
+
+###############################################################################
+#### Install and configure development project
+# Only copy the setup.py, it will still force all install_requires to be installed,
+# but find_packages() will find nothing (which is fine). When Docker Compose mounts the real source
+# over top of this directory, the .egg-link in site-packages resolves to the mounted directory
+# and all package modules are importable.
+COPY ./version.py /opt/django-project/
+COPY ./django-rgd/setup.py /opt/django-project/django-rgd/
+COPY ./django-rgd-3d/setup.py /opt/django-project/django-rgd-3d/
+COPY ./django-rgd-fmv/setup.py /opt/django-project/django-rgd-fmv/
+COPY ./django-rgd-geometry/setup.py /opt/django-project/django-rgd-geometry/
+COPY ./django-rgd-imagery/setup.py /opt/django-project/django-rgd-imagery/
+COPY ./example_project/setup.py /opt/django-project/example_project/
+# Use a directory name which will never be an import name, as isort considers this as first-party.
+# Use `--no-deps` since all dependencies are managed by conda
+WORKDIR /opt/django-project
+RUN pip install \
+    --no-deps \
+    -e ./django-rgd \
+    -e ./django-rgd-3d \
+    -e ./django-rgd-fmv \
+    -e ./django-rgd-geometry \
+    -e ./django-rgd-imagery \
+    -e ./example_project
+
+WORKDIR /opt/django-project/

--- a/django-rgd-imagery/setup.py
+++ b/django-rgd-imagery/setup.py
@@ -46,18 +46,18 @@ setup(
     include_package_data=True,
     install_requires=[
         'bidict',
+        'cmocean',
         f'django-rgd=={__version__}',
         'large-image[memcached]>=1.9.0',
         'large-image-source-gdal>=1.9.0',
         'large-image-source-pil>=1.9.0',
         'large-image-source-tiff>=1.9.0',
-        'pyvips',
-        'tifftools>=1.2.0',
+        'matplotlib',
         'numpy',
         'pystac>=1.1.0',
+        'pyvips',
         'shapely',
-        'matplotlib',
-        'cmocean',
+        'tifftools>=1.2.0',
     ],
     extras_require={
         'worker': [

--- a/django-rgd/setup.py
+++ b/django-rgd/setup.py
@@ -59,18 +59,17 @@ setup(
         'django-girder-utils',
         'django-model-utils',
         'django-oauth-toolkit',
+        'django-s3-file-field[minio]',
         'djangorestframework',
         'drf-yasg',
         'filelock',
+        'flower',
         'GDAL',
         'pooch',
+        'psutil',
         'psycopg2',
         'python-magic',
-        'flower',
-        'psutil',
         'typing_extensions',
-        # Production-only
-        'django-s3-file-field[minio]',
     ],
     extras_require={
         'fuse': [

--- a/docker-compose.override.miniforge.yml
+++ b/docker-compose.override.miniforge.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  django:
+    build:
+      context: .
+      dockerfile: ./dev/miniforge.Dockerfile
+
+  celery:
+    build:
+      context: .
+      dockerfile: ./dev/miniforge.Dockerfile

--- a/docker-compose.override.no-build.yml
+++ b/docker-compose.override.no-build.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  django:
+    image: ghcr.io/resonantgeodata/resonantgeodata/django:main
+
+  celery:
+    image: ghcr.io/resonantgeodata/resonantgeodata/celery:main

--- a/docker-compose.override.no-build.yml
+++ b/docker-compose.override.no-build.yml
@@ -5,3 +5,6 @@ services:
 
   celery:
     image: ghcr.io/resonantgeodata/resonantgeodata/celery:main
+
+  sass:
+    image: ghcr.io/resonantgeodata/resonantgeodata/sass:main

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,74 @@
+name: rgd-env
+channels:
+  - conda-forge
+dependencies:
+  # Core
+  - python=3.8
+  - boto3
+  - celery
+  - django =3.2
+  - django-allauth
+  - django-extensions
+  - django-filter
+  - django-model-utils
+  - djangorestframework
+  - drf-yasg
+  - filelock
+  - flower
+  - GDAL
+  # - libfuse
+  - numpy
+  - pooch
+  - psutil
+  - psycopg2
+  - python-magic
+  - typing_extensions
+  # 3D subpackage
+  - pyntcloud
+  - pyvista
+  # FMV subpackage
+  - ffmpeg
+  # Geometry subpackage
+  - fiona
+  - shapely
+  # Imagery subpackage
+  - bidict
+  - cmocean
+  - large-image
+  - large-image-converter
+  - large-image-source-gdal
+  - large-image-source-tiff
+  - matplotlib
+  - pylibmc >=1.5.1
+  - pystac >=1.1.0
+  - pyvips
+  - rasterio
+  # Example priject
+  - django-crispy-forms
+  - django-debug-toolbar
+  - django-rest-swagger
+  - gunicorn
+  - ipython
+  - pydot
+  - pygraphviz
+  - pyparsing
+  # pip dependencies
+  - pip
+  - pip:
+      # Core
+      - django-click
+      - django-crum
+      - django-composed-configuration[dev]
+      - django-configurations[database,email]>=0.19.2
+      - django-girder-utils
+      - django-oauth-toolkit
+      - django-s3-file-field[minio]
+      # - simple-httpfs
+      # 3D subpackage
+      - pylas  # pyntcloud[LAS]
+      - lazrs  # pyntcloud[LAS]
+      # FMV subpackage
+      - opencv-python-headless
+      - kwiver
+      # Imager subpackage
+      - large-image-source-pil

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -7,3 +7,9 @@ $ docker compose run --rm django ./example_project/manage.py collectstatic
 
 $ docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.demo.yml up
 ```
+
+For using the miniforge environment (useful on M1 Mac):
+
+```
+$ docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml up
+```

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -19,6 +19,5 @@ docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-co
 To use prebuilt images, not building the images locally (time saver):
 
 ```
-docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.no-build.yml build
 docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.no-build.yml up
 ```

--- a/example_project/README.md
+++ b/example_project/README.md
@@ -3,13 +3,22 @@
 For better performance during demos, run:
 
 ```
-$ docker compose run --rm django ./example_project/manage.py collectstatic
+docker compose run --rm django ./example_project/manage.py collectstatic
 
-$ docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.demo.yml up
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.demo.yml up
 ```
 
 For using the miniforge environment (useful on M1 Mac):
 
 ```
-$ docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml up
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml build
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml up
+```
+
+
+To use prebuilt images, not building the images locally (time saver):
+
+```
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.no-build.yml build
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.no-build.yml up
 ```

--- a/example_project/setup.py
+++ b/example_project/setup.py
@@ -36,9 +36,9 @@ setup(
     ],
     extras_require={
         'graph': [
+            'pydot',
             'pygraphviz',
             'pyparsing',
-            'pydot',
         ],
     },
 )


### PR DESCRIPTION
Hopefully, this makes it easier to run RGD within docker (or natively) on an M1 Mac - cc @mcovalt 

At the moment, this will not work with the tox testing environment.

To test:

```bash
docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml build
docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.miniforge.yml up
```

Current image sizes:

```
REPOSITORY                          TAG          IMAGE ID       CREATED        SIZE
django                              latest       4fc25bb20b1b   11 seconds ago   1.37GB
celery                              latest       3f82a97a1242   2 minutes ago    2.93GB
miniforge                           latest       0dc419cbbdaf   2 days ago       4.94GB
```

Once we get to #674, we should try to trim these down and ship a "base image" for downstream RGD projects - having all of the dependencies installed (but not any RGD subpackages)