### PR TITLE
Fix flower service in docker-compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -42,10 +42,13 @@ services:
       - memcached
 
   flower:
-    image: mher/flower
-    command: ["celery", "--broker=amqp://rabbitmq:5672/", "flower"]
+    image: mher/flower:0.9.5
+    command: ["--broker=amqp://rabbitmq:5672/"]
     ports:
       - 5555:5555
+    depends_on:
+      - rabbitmq
+      - celery
 
   sass:
     build:


### PR DESCRIPTION
Pin `flower` services to `mher/flower:0.9.5` due to several issues:

1. Recent releases of flower are not compatible with celery broker URL
2. DockerHub image for `mher/flower` is not following best practices