### PR TITLE
Publish dev wheels from `main`

### DIFF
--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
         with:
-          name: pkg-${{ matrix.rgd-module }}
+          name: pkg-${{ matrix.rgd-module//// }}
           path: ${{ matrix.rgd-module }}/dist/
   publish-wheels:
     name: Publish Wheels

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Set Cache Name
         run:
           CACHE_NAME=$(echo ${{ matrix.rgd-module }} | sed 's/\//\-/g')
+          echo $CACHE_NAME
           echo "CACHE_NAME=$CACHE_NAME" >> $GITHUB_ENV
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
@@ -44,13 +45,13 @@ jobs:
         with:
           # Downloads all artifacts
           path: packages/
+      - run: |
+          ls
+          ls packages/
       - name: Make index
         uses: banesullivan/create-pip-index-action@main
         with:
           package_directory:  packages/
-      - run: |
-          ls
-          ls packages/
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -15,13 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         rgd-module: ['django-rgd', 'django-rgd/client', 'django-rgd-3d', 'django-rgd-fmv', 'django-rgd-geometry', 'django-rgd-imagery', 'django-rgd-imagery/client']
-        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.8"
       - name: Install Dependencies
         run: pip install setuptools wheel
       - name: Build Weel

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
         with:
-          name: pkg-$CACHE_NAME
+          name: pkg-${{ env.CACHE_NAME }}
           path: ${{ matrix.rgd-module }}/dist/
   publish-wheels:
     name: Publish Wheels

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -26,15 +26,10 @@ jobs:
       - name: Build Weel
         working-directory: ${{ matrix.rgd-module }}
         run: python setup.py sdist bdist_wheel
-      - name: Set Cache Name
-        run:
-          CACHE_NAME=$(echo '${{ matrix.rgd-module }}' | sed 's/\//\-/g');
-          echo $CACHE_NAME;
-          echo "CACHE_NAME=$CACHE_NAME" >> $GITHUB_ENV;
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
         with:
-          name: pkg-${{ env.CACHE_NAME }}
+          name: dist
           path: ${{ matrix.rgd-module }}/dist/
           if-no-files-found: error
   publish-wheels:
@@ -44,13 +39,13 @@ jobs:
     steps:
       # Downloads all artifacts
       - uses: actions/download-artifact@v2
-      - run: ls
+      - run: ls; ls dist
       - name: Make index
         uses: banesullivan/create-pip-index-action@main
         with:
-          package_directory:  .
+          package_directory: dist
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir:  .
+          publish_dir:  dist

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -36,18 +36,15 @@ jobs:
         with:
           name: pkg-${{ env.CACHE_NAME }}
           path: ${{ matrix.rgd-module }}/dist/
+          if-no-files-found: error
   publish-wheels:
     name: Publish Wheels
     runs-on: ubuntu-latest
     needs: build-wheels
     steps:
+      # Downloads all artifacts
       - uses: actions/download-artifact@v2
-        with:
-          # Downloads all artifacts
-          path: packages/
-      - run: |
-          ls
-          ls packages/
+      - run: ls
       - name: Make index
         uses: banesullivan/create-pip-index-action@main
         with:

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -26,10 +26,14 @@ jobs:
       - name: Build Weel
         working-directory: ${{ matrix.rgd-module }}
         run: python setup.py sdist bdist_wheel
+      - name: Set Cache Name
+        run:
+          CACHE_NAME=$(echo ${{ matrix.rgd-module }} | sed 's/\//\-/g')
+          echo "CACHE_NAME=$CACHE_NAME" >> $GITHUB_ENV
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
         with:
-          name: pkg-${{ matrix.rgd-module//// }}
+          name: pkg-$CACHE_NAME
           path: ${{ matrix.rgd-module }}/dist/
   publish-wheels:
     name: Publish Wheels

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -2,9 +2,10 @@ name: Publish Dev Wheels to GitHub Pages
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   # Upload wheels to GH Pages package index
@@ -33,7 +34,7 @@ jobs:
           path: ${{ matrix.rgd-module }}/dist/
           if-no-files-found: error
   publish-wheels:
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     name: Publish Wheels
     runs-on: ubuntu-latest
     needs: build-wheels

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Make index
         uses: banesullivan/create-pip-index-action@main
         with:
-          package_directory:  packages/
+          package_directory:  .
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir:  packages/
+          publish_dir:  .

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -15,12 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         rgd-module: ['django-rgd', 'django-rgd/client', 'django-rgd-3d', 'django-rgd-fmv', 'django-rgd-geometry', 'django-rgd-imagery', 'django-rgd-imagery/client']
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: pip install setuptools wheel
       - name: Build Weel
@@ -33,13 +34,13 @@ jobs:
           path: ${{ matrix.rgd-module }}/dist/
           if-no-files-found: error
   publish-wheels:
+    # if: github.ref == 'refs/heads/main'
     name: Publish Wheels
     runs-on: ubuntu-latest
     needs: build-wheels
     steps:
       # Downloads all artifacts
       - uses: actions/download-artifact@v2
-      - run: ls; ls dist
       - name: Make index
         uses: banesullivan/create-pip-index-action@main
         with:

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -48,6 +48,9 @@ jobs:
         uses: banesullivan/create-pip-index-action@main
         with:
           package_directory:  packages/
+      - run: |
+          ls
+          ls packages/
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -28,9 +28,9 @@ jobs:
         run: python setup.py sdist bdist_wheel
       - name: Set Cache Name
         run:
-          CACHE_NAME=$(echo ${{ matrix.rgd-module }} | sed 's/\//\-/g')
-          echo $CACHE_NAME
-          echo "CACHE_NAME=$CACHE_NAME" >> $GITHUB_ENV
+          CACHE_NAME=$(echo '${{ matrix.rgd-module }}' | sed 's/\//\-/g');
+          echo $CACHE_NAME;
+          echo "CACHE_NAME=$CACHE_NAME" >> $GITHUB_ENV;
       - name: Cache Wheel
         uses: actions/upload-artifact@v2
         with:

--- a/version.py
+++ b/version.py
@@ -15,7 +15,7 @@ Which denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 2, '16dev'
+version_info = 0, 2, '16dev0'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/version.py
+++ b/version.py
@@ -15,7 +15,7 @@ Which denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 2, 15
+version_info = 0, 2, '16dev'
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Sets up a new GitHub action to publish wheels/sdist from `main` to GitHub Pages. Why? So that we can easily install from `main` for testing downstream projects without publishing a release to PyPI. Installing from git source isn't all that easy for us in some environments but using `--find-links` is.

Check out https://resonantgeodata.github.io/ResonantGeoData/

This also builds the wheels for every PR and uploads as a build artifact