### PR TITLE
Add `percent_overlap` filter

### DIFF
--- a/django-rgd/rgd/filters.py
+++ b/django-rgd/rgd/filters.py
@@ -81,6 +81,7 @@ class SpatialEntryFilter(filters.FilterSet):
         queryset=Collection.objects.all(),
     )
     percent_overlap = filters.NumberFilter(
+        help_text='The minute percent overlap with search geometry (between 0 and 1).',
         label='Percent overlap',
         method='filter_percent_overlap',
     )

--- a/django-rgd/rgd/filters.py
+++ b/django-rgd/rgd/filters.py
@@ -162,11 +162,11 @@ class SpatialEntryFilter(filters.FilterSet):
         if value and value > 0 and value < 1 and self._has_geom:
             geom = self._geometry
             queryset = queryset.filter(footprint__overlaps=geom).annotate(
-                intersection_geom=(
+                overlap_percentage=(
                     Cast(Area(Intersection(F('footprint'), geom)) / Area(geom), FloatField())
                 )
             )
-            queryset = queryset.filter(intersection_geom__gte=value)
+            queryset = queryset.filter(overlap_percentage__gte=value)
         return queryset
 
     class Meta:

--- a/django-rgd/rgd/filters.py
+++ b/django-rgd/rgd/filters.py
@@ -160,7 +160,7 @@ class SpatialEntryFilter(filters.FilterSet):
 
     def filter_percent_overlap(self, queryset, name, value: float):
         """Filter the queryset by percent overlap with the queried geometry."""
-        if value and value > 0 and value < 1 and self._has_geom:
+        if value is not None and value > 0 and value <= 1 and self._has_geom:
             geom = self._geometry
             queryset = queryset.filter(footprint__overlaps=geom).annotate(
                 overlap_percentage=(

--- a/django-rgd/rgd/templates/rgd/_include/search_fields.html
+++ b/django-rgd/rgd/templates/rgd/_include/search_fields.html
@@ -68,6 +68,19 @@
 
   <div class="column is-full field mb-0">
     <div class="field-label is-normal">
+      <label class="label">Percent Overlap</label>
+    </div>
+    <div class="field-body">
+      <div class="field">
+        <div class="control">
+          <input class="input" type="text" name="percent_overlap" value="{{ request.GET.percent_overlap }}">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="column is-full field mb-0">
+    <div class="field-label is-normal">
       <label class="label">Instrumentation</label>
     </div>
     <div class="field-body">


### PR DESCRIPTION
@banesullivan the issue specifies "A user wants to be able to search for SpatialEntries that have x% overlap with the search geometry". I implemented this so all SpatialEntries that overlap the search geometry by *at least* x% are shown. I figured that is better than only matching the exact percentage given. Does that make sense, or do we want an exact match?

Closes #462 