### PR TITLE
Optimize rgd_imagery admin page queries

### DIFF
--- a/django-rgd-imagery/rgd_imagery/models/base.py
+++ b/django-rgd-imagery/rgd_imagery/models/base.py
@@ -1,6 +1,7 @@
 """Base classes for raster dataset entries."""
 from django.contrib.gis.db import models
 from django.contrib.postgres.fields import DecimalRangeField
+from django.db.models import Count, Sum
 from django_extensions.db.models import TimeStampedModel
 from rgd.models import ChecksumFile, SpatialEntry
 from rgd.models.mixins import DetailViewMixin, TaskEventMixin
@@ -84,7 +85,9 @@ class ImageSet(TimeStampedModel):
 
     @property
     def number_of_bands(self):
-        return sum([im.number_of_bands for im in self.images.all()])
+        return self.images.annotate(band_count=Count('bandmeta')).aggregate(Sum('band_count'))[
+            'band_count__sum'
+        ]
 
     @property
     def width(self):


### PR DESCRIPTION
I was using the Django admin to debug #666 and I noticed the `Image` and `ImageSet` list pages were taking 3-5 seconds to load. It turns out, for N rows in the image/image set tables, approximately O(2N) SQL queries are being executed on page load. So, I made some optimizations to make debugging less painful. 
With these changes, my `ImageSet` list page went from 204 queries to 5 queries for 71 rows. It looks like there's still some repetitive queries being made, but not enough to have a major impact on page load time.