### PR TITLE
Set `DEFAULT_PAGINATION_CLASS` and `PAGE_SIZE` in test app

### DIFF
--- a/django-rgd-imagery/tests/test_client.py
+++ b/django-rgd-imagery/tests/test_client.py
@@ -25,7 +25,7 @@ bbox = {
 def test_inspect_raster(py_client: ImageryClient, sample_raster_multi):
     q = py_client.rgd.search(query=json.dumps(bbox), predicate='intersects')
     raster_meta = next(
-        (x for x in q if x['subentry_name'] == 'Multi File Test'),
+        (x for x in q['results'] if x['subentry_name'] == 'Multi File Test'),
         None,
     )
 
@@ -57,10 +57,11 @@ def test_get_raster(py_client: ImageryClient, sample_raster_multi):
 def test_download_raster(py_client: ImageryClient, sample_raster_multi):
     q = py_client.rgd.search(query=json.dumps(bbox), predicate='intersects')
 
-    assert len(q) >= 1
+    assert q['count'] >= 1
+    assert len(q['results']) >= 1
 
     try:
-        py_client.imagery.download_raster(q[0])
+        py_client.imagery.download_raster(q['results'][0])
     except Exception as e:
         print(e)
         pytest.fail('Failed to download raster image set')

--- a/django-rgd/README.md
+++ b/django-rgd/README.md
@@ -29,6 +29,11 @@ INSTALLED_APPS += [
 MIDDLEWARE += ('crum.CurrentRequestUserMiddleware',)
 
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ('rest_framework.authentication.TokenAuthentication',)
+
+# doesn't have to use girder_utils if downstream projects don't have it installed, but this must be set to *something* valid to enable pagination in the API
+REST_FRAMEWORK['DEFAULT_PAGINATION_CLASS'] = 'girder_utils.rest_framework.BoundedLimitOffsetPagination'
+
+REST_FRAMEWORK['PAGE_SIZE'] = 100 # or whatever default pagination size you want
 ```
 
 (note that RGD requires [`django-crum`](https://django-crum.readthedocs.io/en/latest/) middleware.)

--- a/django-rgd/tests/test_client.py
+++ b/django-rgd/tests/test_client.py
@@ -25,7 +25,8 @@ def test_basic_search(py_client: RgdClient, spatial_asset_a):
     }
 
     q = py_client.rgd.search(query=json.dumps(bbox), predicate='intersects')
-    assert len(q) == 1
+    assert q['count'] == 1
+    assert len(q['results']) == 1
 
 
 @pytest.mark.django_db(transaction=True)

--- a/testing-utils/rgd_testing_utils/settings.py
+++ b/testing-utils/rgd_testing_utils/settings.py
@@ -81,7 +81,10 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
-    ]
+    ],
+    # The following two settings enable pagination and were taken from django-composed-configuration:
+    'DEFAULT_PAGINATION_CLASS': 'girder_utils.rest_framework.BoundedLimitOffsetPagination',
+    'PAGE_SIZE': 100,
 }
 
 SITE_ID = 1


### PR DESCRIPTION
Closes #638 

The problem was that the test app didn't have pagination enabled, so it was just returning a flat list instead of a dict of the form
```
{
	"count": 100,
	"next": "http://localhost:8000/api/rgd/checksum_file?limit=100&offset=100",
	"previous": null,
	"results": [....]
}
```