### PR TITLE
Add RGD_OUTPUT_FILE_HANDLER

### DIFF
--- a/django-rgd-3d/rgd_3d/tasks/etl.py
+++ b/django-rgd-3d/rgd_3d/tasks/etl.py
@@ -14,17 +14,19 @@ from rgd_3d.models import Mesh3D, Tiles3D, Tiles3DMeta
 logger = get_task_logger(__name__)
 
 
-def _file_conversion_helper(source, output, method, prefix='', extension='', **kwargs):
+def _file_conversion_helper(
+    source: ChecksumFile, output: ChecksumFile, method: callable, extension: str = '', **kwargs
+):
     workdir = get_temp_dir()
     with tempfile.TemporaryDirectory(dir=workdir) as tmpdir:
         # NOTE: cannot use FUSE with PyntCloud because it checks file extension
         #       in path. Additionally, The `name` field for the file MUST have
         #       the extension.
         with source.yield_local_path(try_fuse=False) as file_path:
-            output_path = os.path.join(tmpdir, prefix + os.path.basename(source.name) + extension)
+            output_path = os.path.join(tmpdir, os.path.basename(source.name) + extension)
             method(str(file_path), str(output_path), **kwargs)
         with open(output_path, 'rb') as f:
-            output.save_file_contents(f, os.path.basename(output_path))
+            output.save_file_contents(f, source.name + extension)
 
 
 def _save_pyvista(mesh, output_path):

--- a/django-rgd-3d/rgd_3d/tasks/etl.py
+++ b/django-rgd-3d/rgd_3d/tasks/etl.py
@@ -1,7 +1,7 @@
 import json
 import os
 import tempfile
-from typing import Union
+from typing import Callable, Union
 
 from celery.utils.log import get_task_logger
 from django.contrib.gis.geos import Polygon
@@ -15,7 +15,7 @@ logger = get_task_logger(__name__)
 
 
 def _file_conversion_helper(
-    source: ChecksumFile, output: ChecksumFile, method: callable, extension: str = '', **kwargs
+    source: ChecksumFile, output: ChecksumFile, method: Callable, extension: str = '', **kwargs
 ):
     workdir = get_temp_dir()
     with tempfile.TemporaryDirectory(dir=workdir) as tmpdir:

--- a/django-rgd-3d/tests/test_point_cloud.py
+++ b/django-rgd-3d/tests/test_point_cloud.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+import tempfile
+
 import pytest
 from rgd.datastore import datastore
+from rgd.models import FileSourceType
 from rgd_3d.tasks.etl import read_mesh_3d_file
 
 from . import factories
@@ -21,3 +25,30 @@ def test_mesh_3d_etl(sample_file):
     assert entry.vtp_data is not None
     # Testing that we can repopulate a point cloud entry
     read_mesh_3d_file(entry.id)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_mesh_3d_etl_custom_output_handler(settings):
+
+    directory = tempfile.gettempdir()
+
+    def output_file_handler(instance, file_handle, name):
+        # save to path on disk and give `file://` URL to ChecksumFile
+        path = Path(directory, name)
+        with open(path, 'wb') as f:
+            f.write(file_handle.read())
+        instance.type = FileSourceType.URL
+        instance.url = f'file://{path}'
+        instance.file = None
+
+    settings.RGD_OUTPUT_FILE_HANDLER = output_file_handler
+
+    entry = factories.Mesh3DFactory(
+        file__file__filename='topo.vtk',
+        file__file__from_path=datastore.fetch(
+            'topo.vtk',
+        ),
+    )
+    entry.refresh_from_db()
+    assert entry.vtp_data is not None
+    assert entry.vtp_data.url.startswith(f'file://{directory}')

--- a/django-rgd-imagery/rgd_imagery/tasks/subsample.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/subsample.py
@@ -57,7 +57,7 @@ def convert_to_cog(param_model):
     """Convert Image to Cloud Optimized GeoTIFF."""
     with _processed_image_helper(param_model, single_input=True) as (image, output):
 
-        with input_output_path_helper(image.file, output, prefix='cog_') as (
+        with input_output_path_helper(image.file, output, prefix='cog_', suffix='.tif') as (
             input_path,
             output_path,
         ):

--- a/django-rgd-imagery/rgd_imagery/tasks/subsample.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/subsample.py
@@ -129,7 +129,7 @@ def extract_region(processed_image):
 
     with _processed_image_helper(processed_image, single_input=True) as (image, output):
         filename = f'region-{image.file.name}'
-        with output_path_helper(filename, output.file) as output_path:
+        with output_path_helper(filename, output) as output_path:
             logger.debug(f'The extent: {l, r, b, t}')
             if sample_type in (
                 SampleTypes.GEOJSON,
@@ -201,7 +201,7 @@ def mosaic_images(processed_image):
             with image.file.yield_local_path(yield_file_set=True) as file_path:
                 src_files_to_mosaic.append(rasterio.open(file_path))
 
-        with output_path_helper('mosaic.tif', output.file) as output_path:
+        with output_path_helper('mosaic.tif', output) as output_path:
             mosaic, out_trans = merge(src_files_to_mosaic)
             out_meta = src_files_to_mosaic[0].meta.copy()
 

--- a/django-rgd-imagery/rgd_imagery/tasks/subsample.py
+++ b/django-rgd-imagery/rgd_imagery/tasks/subsample.py
@@ -57,7 +57,7 @@ def convert_to_cog(param_model):
     """Convert Image to Cloud Optimized GeoTIFF."""
     with _processed_image_helper(param_model, single_input=True) as (image, output):
 
-        with input_output_path_helper(image.file, output.file, prefix='cog_') as (
+        with input_output_path_helper(image.file, output, prefix='cog_') as (
             input_path,
             output_path,
         ):
@@ -154,7 +154,7 @@ def resample_image(processed_image):
     with _processed_image_helper(processed_image, single_input=True) as (image, output):
 
         with input_output_path_helper(
-            image.file, output.file, prefix='resampled_{:.2f}_'.format(factor)
+            image.file, output, prefix='resampled_{:.2f}_'.format(factor)
         ) as (
             input_path,
             output_path,

--- a/django-rgd/client/rgd_client/pytorch.py
+++ b/django-rgd/client/rgd_client/pytorch.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Callable, Union
 
 from rgd_client.client import RgdClient
 from torch.utils.data import Dataset
@@ -15,14 +15,14 @@ class RemoteDataset(Dataset):
         collection).
     client: RgdClient
         The client connected to an RGD instance.
-    data_handler : callable
+    data_handler : Callable
         A callable that will handle converting the data from a ChecksumFile to
         something usable by PyTorch.
 
     """
 
     def __init__(
-        self, collection: Union[int, str, dict], client: RgdClient, data_handler: callable = None
+        self, collection: Union[int, str, dict], client: RgdClient, data_handler: Callable = None
     ):
         self._client = client
         self._collection_identifier = collection

--- a/django-rgd/rgd/management/commands/_data_helper.py
+++ b/django-rgd/rgd/management/commands/_data_helper.py
@@ -68,7 +68,7 @@ def _get_or_create_checksum_file_filefield(file: str, name=None, use_datastore: 
         else:
             file_entry.name = file
         with open(path, 'rb') as f:
-            file_entry.file.save(os.path.basename(path), f)
+            file_entry.save_file_contents(f, os.path.basename(path))
         file_entry.type = models.FileSourceType.FILE_FIELD
         _save_signal(file_entry, True)
     return file_entry

--- a/django-rgd/rgd/models/file.py
+++ b/django-rgd/rgd/models/file.py
@@ -335,7 +335,6 @@ class ChecksumFile(TimeStampedModel, TaskEventMixin):
                     f'`output_file_handler` not understood: {settings.RGD_OUTPUT_FILE_HANDLER}'
                 )
             func(self, file_handle, name)
-
         else:
             if not self.name:
                 self.name = name

--- a/django-rgd/rgd/models/utils.py
+++ b/django-rgd/rgd/models/utils.py
@@ -71,7 +71,7 @@ def get_or_create_checksumfile_file_field(
         # Since we already computed the checksum, prevent tasks from recomputing
         file_entry.skip_signal = True
         file_handle.seek(0)
-        file_entry.file.save('test', file_handle)
+        file_entry.save_file_contents(file_handle, 'test')
         file_entry.save()
         file_entry.skip_signal = False
     return file_entry, created

--- a/django-rgd/rgd/rest/viewsets.py
+++ b/django-rgd/rgd/rest/viewsets.py
@@ -22,7 +22,7 @@ class CollectionViewSet(ModelViewSet):
 
     @swagger_auto_schema(
         method='GET',
-        operation_summary='Get the file at the given index in this collection. Associated files are orderd by primary key and the provided index is the index in that ordered set. If the files in the collection change, this will not be reproducible.',
+        operation_summary='Get the file at the given index in this collection. Associated files are ordered by primary key and the provided index is the index in that ordered set. If the files in the collection change, this will not be reproducible.',
     )
     @action(
         detail=True,

--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -140,7 +140,7 @@ def download_url_file_to_local_path(
         # File available on localfilesystem
         true_path = Path(url.replace('file://', '', 1)).absolute()
         if dest_path.exists() and not os.path.islink(str(dest_path)):
-            os.remove(dest_path)  # Remove file incase touched
+            os.remove(dest_path)  # Remove file in case touched
         if not dest_path.exists():
             os.symlink(true_path, dest_path)
         # else exists and is a symlink - ASSUME it is correct
@@ -214,7 +214,7 @@ def patch_internal_presign(f: FieldFile):
 
 
 @contextmanager
-def output_path_helper(filename: str, output: FieldFile):
+def output_path_helper(filename: str, output: ChecksumFile):
     workdir = get_temp_dir()
     with tempfile.TemporaryDirectory(dir=workdir) as tmpdir:
         output_path = os.path.join(tmpdir, filename)
@@ -226,11 +226,11 @@ def output_path_helper(filename: str, output: FieldFile):
         else:
             # Save the file contents to the output field only on success
             with open(output_path, 'rb') as f:
-                output.save(os.path.basename(output_path), f)
+                output.save_file_contents(f, os.path.basename(output_path))
 
 
 @contextmanager
-def input_output_path_helper(source, output: FieldFile, prefix: str = '', suffix: str = ''):
+def input_output_path_helper(source, output: ChecksumFile, prefix: str = '', suffix: str = ''):
     """Yield source and output paths between a ChecksumFile and a FileFeild.
 
     The output path is saved to the output field after yielding.
@@ -248,7 +248,7 @@ def input_output_path_helper(source, output: FieldFile, prefix: str = '', suffix
             else:
                 # Save the file contents to the output field only on success
                 with open(output_path, 'rb') as f:
-                    output.save(os.path.basename(output_path), f)
+                    output.save_file_contents(f, os.path.basename(output_path))
 
 
 def uuid_prefix_filename(instance: Any, filename: str):

--- a/django-rgd/rgd/utility.py
+++ b/django-rgd/rgd/utility.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import shutil
 import tempfile
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -101,7 +101,7 @@ def _link_url(obj: Model, field: str):
     return mark_safe(f'<a href="{url}" download>Download</a>')
 
 
-def get_or_create_no_commit(model: Model, defaults: dict = None, **kwargs):
+def get_or_create_no_commit(model: Model, defaults: Optional[dict] = None, **kwargs):
     try:
         return model.objects.get(**kwargs), False
     except model.DoesNotExist:
@@ -214,7 +214,7 @@ def patch_internal_presign(f: FieldFile):
 
 
 @contextmanager
-def output_path_helper(filename: str, output: ChecksumFile, final_name: str = None):
+def output_path_helper(filename: str, output: ChecksumFile, final_name: Optional[str] = None):
     if final_name is None:
         final_name = os.path.basename(filename)
     workdir = get_temp_dir()

--- a/django-rgd/tests/test_checksumfile.py
+++ b/django-rgd/tests/test_checksumfile.py
@@ -1,5 +1,6 @@
 import io
 from pathlib import Path
+import tempfile
 
 from django.db import IntegrityError
 import pytest
@@ -161,9 +162,11 @@ def test_get_or_create_url_checksum():
 
 @pytest.mark.django_db(transaction=True)
 def test_output_file_handler(settings, file_path):
+    directory = tempfile.gettempdir()
+
     def output_file_handler(instance: ChecksumFile, file_handle: io.BufferedIOBase, name: str):
         # save to path on disk and give `file://` URL to ChecksumFile
-        path = Path('/opt/django-project/.tox/', name)
+        path = Path(directory, name)
         with open(path, 'wb') as f:
             f.write(file_handle.read())
         instance.type = FileSourceType.URL
@@ -176,4 +179,4 @@ def test_output_file_handler(settings, file_path):
     with open(file_path, 'rb') as f:
         file.save_file_contents(f, FILENAME)
     file.save()
-    assert file.url == f'file://{str(Path("/opt/django-project/.tox/", FILENAME))}'
+    assert file.url == f'file://{str(Path(directory, FILENAME))}'

--- a/django-rgd/tests/test_checksumfile.py
+++ b/django-rgd/tests/test_checksumfile.py
@@ -1,3 +1,4 @@
+import io
 from pathlib import Path
 
 from django.db import IntegrityError
@@ -156,3 +157,23 @@ def test_get_or_create_url_checksum():
     assert created
     file, created = utils.get_or_create_checksumfile(url=url, precompute_url_checksum=True)
     assert not created
+
+
+@pytest.mark.django_db(transaction=True)
+def test_output_file_handler(settings, file_path):
+    def output_file_handler(instance: ChecksumFile, file_handle: io.BufferedIOBase, name: str):
+        # save to path on disk and give `file://` URL to ChecksumFile
+        path = Path('/opt/django-project/.tox/', name)
+        with open(path, 'wb') as f:
+            f.write(file_handle.read())
+        instance.type = FileSourceType.URL
+        instance.url = f'file://{path}'
+        instance.file = None
+
+    settings.RGD_OUTPUT_FILE_HANDLER = output_file_handler
+
+    file = ChecksumFile()
+    with open(file_path, 'rb') as f:
+        file.save_file_contents(f, FILENAME)
+    file.save()
+    assert file.url == f'file://{str(Path("/opt/django-project/.tox/", FILENAME))}'


### PR DESCRIPTION
This adds a new feature to be able to control how some of RGD's ETL routines save generated/converted data as we may not always want to upload the data to S3FF.

On a downstream project, I need to save the data to a local path on disk rather than in minio/S3FF and this feature enables that.