### PR TITLE
Fix VTK viewer styling on Mesh3D admin page

### DIFF
--- a/django-rgd-3d/rgd_3d/templates/rgd_3d/_include/vtkjs_viewer.html
+++ b/django-rgd-3d/rgd_3d/templates/rgd_3d/_include/vtkjs_viewer.html
@@ -5,25 +5,35 @@
     width: 100%;
     height: 100%;
     position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   #vtkContainer {
     width: 100%;
     height: 100%;
-    position: relative;
+    position: absolute;
   }
 
   .progress {
     color: black;
     z-index: 100;
     background: rgba(128, 128, 128, .5);
-    padding: 100px;
     border-radius: 10px;
     user-select: none;
-    width: 25%;
+    width: 80%;
+    height: 20%;
     text-align: center;
     margin: 20% auto;
-    position: relative;
+    position: absolute;
+  }
+
+  #loadingContainer {
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
   }
 </style>
 
@@ -31,7 +41,9 @@
   <div id="vtkContainer">
   </div>
   <div class="progress" id="progressContainer">
-    <h1>Loading...</h1>
+    <div id="loadingContainer">
+      <h1>Loading...</h1>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
The main source of this bug was that it was using a `z-index` to overlay the "Loading" text on top of the VTK viewer. The overlaid elements had a `position` of  `relative`, which doesn't work with `z-index`. I fixed it by changing them to have `position: absolute`; this introduced some alignment issues which I fixed with flexbox.

Here's what it looks like now - (I throttled my download speed so that the loading bar shows up for an extended period of time)

![Peek 2022-04-18 15-34](https://user-images.githubusercontent.com/37340715/163866481-b12a37b0-85cb-460c-8253-db373a3cf6d2.gif)
