### PR TITLE
Patch `FMVMetaDataSerializer` to return footprints as GeoJSON instead of SRID string

### DIFF
--- a/django-rgd-fmv/rgd_fmv/serializers.py
+++ b/django-rgd-fmv/rgd_fmv/serializers.py
@@ -6,6 +6,7 @@ from rgd.serializers import (
     TASK_EVENT_READ_ONLY_FIELDS,
     ChecksumFileSerializer,
     RelatedField,
+    SpatialEntryFootprintSerializer,
     SpatialEntrySerializer,
 )
 
@@ -35,7 +36,7 @@ class FMVMetaSerializer(SpatialEntrySerializer):
         ]
 
 
-class FMVMetaDataSerializer(FMVMetaSerializer):
+class FMVMetaDataSerializer(FMVMetaSerializer, SpatialEntryFootprintSerializer):
     def to_representation(self, value):
         ret = super().to_representation(value)
         ret['ground_frames'] = json.loads(value.ground_frames.geojson)


### PR DESCRIPTION
Updates the serializer to return a GeoJSON footprint instead of a string