### PR TITLE
Deserialize `frame_numbers` to array in FMV data endpoint

### DIFF
--- a/django-rgd-fmv/rgd_fmv/serializers.py
+++ b/django-rgd-fmv/rgd_fmv/serializers.py
@@ -41,6 +41,7 @@ class FMVMetaDataSerializer(FMVMetaSerializer):
         ret['ground_frames'] = json.loads(value.ground_frames.geojson)
         ret['ground_union'] = json.loads(value.ground_union.geojson)
         ret['flight_path'] = json.loads(value.flight_path.geojson)
+        ret['frame_numbers'] = value._blob_to_array(value.frame_numbers)
         return ret
 
     class Meta:


### PR DESCRIPTION
Currently, since it is a `BinaryField`, the `FMVMeta.frame_numbers` field is not deserialized before being sent as part of the response. So, the value returned as part of the fmv `/data` endpoint response isn't readable by the client, as it comes back as what appears to be a string encoding of the data. This PR updates the serializer to explicitly serialize the data into a JSON array before sending it back to the client.