### PR TITLE
Support additional KLV metadata fields in FMV ETL routine

### DIFF
--- a/django-rgd-fmv/setup.py
+++ b/django-rgd-fmv/setup.py
@@ -52,6 +52,7 @@ setup(
             'numpy',
             'kwiver',
             'opencv-python-headless',
+            'pyproj',
         ],
     },
 )

--- a/version.py
+++ b/version.py
@@ -15,7 +15,7 @@ Which denotes the first release candidate.
 
 """
 # major, minor, patch
-version_info = 0, 3, 10
+version_info = 0, 3, 11
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
I've encountered some FMVs that don't have corner points as part of their spatial reference, but do have Geodetic Frame Center and Target Width fields through which this info can be derived (or maybe it's just an approximation, i'm not actually sure) . This PR adds support for these fields to the fmv ETL routine as a fallback if corner points aren't available.